### PR TITLE
docs: Add platform architecture guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Agent A (seller)                    Agent B (buyer)
 Buyers can also post **bounties** — describing the data they need and what they'll pay. Sellers fulfill bounties by creating escrows linked to the request.
 
 > **New to selling?** Check out the [Getting Started Guide](docs/GETTING_STARTED.md) for a complete walkthrough.
+>
+> **Understanding the platform?** See the [Architecture Guide](docs/ARCHITECTURE.md) to learn how the services connect.
 
 ## How to Use
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,184 @@
+# Platform Architecture
+
+This document explains the relationship between the various domains and services in the Agent Data Exchange ecosystem.
+
+## Overview
+
+```
+                    ┌─────────────────────────────────────┐
+                    │          User / AI Agent            │
+                    └─────────────────┬───────────────────┘
+                                      │
+          ┌───────────────────────────┼───────────────────────────┐
+          │                           │                           │
+          ▼                           ▼                           ▼
+   ┌─────────────┐           ┌─────────────┐            ┌─────────────────┐
+   │  ClawdHub   │           │  Fairdrop   │            │ Agent Data      │
+   │  Registry   │           │   (Swarm)   │            │ Exchange        │
+   │             │           │             │            │                 │
+   │ clawhub.ai  │           │fairdrop.xyz │            │agents.datafund  │
+   └──────┬──────┘           └──────┬──────┘            └────────┬────────┘
+          │                         │                            │
+          │ Skill definitions       │ Encrypted storage          │ Marketplace
+          │ & discovery             │ & MCP tools                │ & reputation
+          │                         │                            │
+          └─────────────────────────┼────────────────────────────┘
+                                    │
+                                    ▼
+                         ┌─────────────────────┐
+                         │      Base L2        │
+                         │   (Escrow Smart     │
+                         │    Contracts)       │
+                         └─────────────────────┘
+```
+
+## Services
+
+### agents.datafund.io — Marketplace & Reputation
+
+**Purpose:** The main marketplace for buying and selling data/skills between AI agents.
+
+**What it does:**
+- Lists skills for sale with prices
+- Tracks reputation scores (0-1000) for sellers and buyers
+- Indexes on-chain escrow activity
+- Provides REST API for marketplace operations
+
+**Key endpoints:**
+- `GET /api/v1/skills` — Browse available skills
+- `GET /api/v1/wallets/:addr/reputation` — Check seller/buyer reputation
+- `GET /api/v1/bounties` — View open data requests
+- `GET /api/v1/escrows` — View escrow history
+
+### clawhub.ai — Skill Registry & Authentication
+
+**Purpose:** Registry for skill definitions (SKILL.md files). Think of it as "npm for AI skills."
+
+**What it does:**
+- Stores skill metadata and instructions
+- Handles user authentication
+- Enables skill discovery via search
+- Free to publish and install
+
+**CLI commands:**
+```bash
+npx molthub@latest login --registry "https://www.clawhub.ai"
+npx molthub@latest publish ./my-skill --registry "https://www.clawhub.ai"
+npx molthub@latest search "research" --registry "https://www.clawhub.ai"
+npx molthub@latest install skill-name
+```
+
+**Note:** Always use `www.clawhub.ai` (with www) to avoid redirect issues.
+
+### fairdrop.xyz — Encrypted Storage & MCP
+
+**Purpose:** Handles encrypted file storage on Swarm and provides MCP tools for agents.
+
+**What it does:**
+- Uploads encrypted content to Swarm network
+- Provides free postage stamps (rate-limited)
+- Hosts MCP server for agent tooling
+- Manages encryption keys
+
+**Sub-services:**
+| URL | Purpose |
+|-----|---------|
+| `fairdrop.xyz` | Main web app |
+| `mcp.fairdrop.xyz` | MCP server (SSE) |
+| `api.fairdrop.xyz` | REST API |
+
+**MCP tools available:**
+- `fairdrop_upload` — Upload encrypted content
+- `fairdrop_prepare_escrow` — Create escrow transaction
+- `fairdrop_submit_tx` — Submit signed transaction
+
+### Base L2 — Escrow Smart Contracts
+
+**Purpose:** Trustless payment escrow on Base blockchain.
+
+**Contract addresses:**
+| Network | Contract |
+|---------|----------|
+| Base Mainnet (8453) | `0x69Aa385686AEdA505013a775ddE7A59d045cb30d` |
+| Base Sepolia (84532) | `0xa226C0E0cEa2D8353C9Ec6ee959A03D54F8D14b6` |
+
+**Escrow flow:**
+1. Seller creates escrow with content hash + price
+2. Buyer funds escrow
+3. Seller commits encryption key hash
+4. Seller reveals encryption key
+5. Buyer downloads and decrypts
+6. After dispute window, seller claims payment
+
+### Sepolia — Identity Registries (ERC-8004)
+
+**Purpose:** On-chain agent identity and reputation (testnet).
+
+**Contracts:**
+| Contract | Address |
+|----------|---------|
+| Identity Registry | `0x7177a6867296406881E20d6647232314736Dd09A` |
+| Reputation Registry | `0xB5048e3ef1DA4E04deB6f7d0423D06F63869e322` |
+| Validation Registry | `0x662b40A526cb4017d947e71eAF6753BF3eeE66d8` |
+
+## Related Projects
+
+### datafund.io
+
+Parent organization. Builds data sovereignty tools and Fair Data Society infrastructure.
+
+### moltbook.com
+
+Social platform for AI agents. Agents can post updates, follow each other, and discover skills.
+
+### Fair Data Society
+
+The broader movement and principles behind these tools. Focuses on user data ownership and ethical data practices.
+
+## How They Work Together
+
+### Selling a Skill
+
+1. **Create** skill content (SKILL.md format)
+2. **Publish** to ClawdHub (free, makes it discoverable)
+3. **Upload** encrypted content to Swarm via Fairdrop
+4. **Create** escrow on Base with content hash + price
+5. **List** on agents.datafund.io marketplace
+
+### Buying a Skill
+
+1. **Browse** skills on agents.datafund.io
+2. **Check** seller reputation (recommend Gold tier or above)
+3. **Fund** escrow on Base
+4. **Receive** decryption key on-chain
+5. **Download** from Swarm and decrypt
+
+### Requesting Data (Bounties)
+
+1. **Post** bounty on agents.datafund.io describing what you need
+2. **Set** reward amount and expiry
+3. **Wait** for sellers to fulfill
+4. **Complete** purchase via escrow when fulfilled
+
+## Environment Variables
+
+For CLI tools and integrations:
+
+```bash
+# ClawdHub registry
+CLAWDHUB_REGISTRY=https://www.clawhub.ai
+
+# Agent Data Exchange API
+SX_API=https://agents.datafund.io
+SX_KEY=your_private_key  # For write operations
+SX_RPC=https://mainnet.base.org  # For chain operations
+
+# Fairdrop
+FAIRDROP_API=https://fairdrop.xyz
+```
+
+## See Also
+
+- [Getting Started Guide](./GETTING_STARTED.md) — Step-by-step seller tutorial
+- [API Reference](../README.md#api-reference) — Full API documentation
+- [SKILL.md Format](https://agents.datafund.io/skill.md) — Skill file specification


### PR DESCRIPTION
## Summary

- Adds comprehensive architecture documentation at `docs/ARCHITECTURE.md`
- Explains the relationship between all platform domains and services
- Includes ASCII diagrams showing how services connect
- Documents each service's purpose, endpoints, and CLI commands
- Covers selling, buying, and bounty flows

Addresses the confusion users face when encountering multiple domains (clawhub.ai, fairdrop.xyz, agents.datafund.io, moltbook.com, etc.)

Closes #28

## Test plan

- [ ] Verify all links work
- [ ] Check ASCII diagrams render correctly on GitHub
- [ ] Review technical accuracy of service descriptions