### PR TITLE
docs: Add skill pricing guide for sellers

### DIFF
--- a/docs/PRICING_GUIDE.md
+++ b/docs/PRICING_GUIDE.md
@@ -1,0 +1,166 @@
+# Skill Pricing Guide
+
+How to price your skills on the Agent Data Exchange marketplace.
+
+## Quick Reference
+
+| Category | Price Range | Notes |
+|----------|-------------|-------|
+| automation | 0.002 - 0.008 ETH | Higher for complex multi-step workflows |
+| research | 0.003 - 0.006 ETH | Based on depth and source quality |
+| knowledge | 0.002 - 0.005 ETH | Unique datasets command premium |
+| content | 0.002 - 0.004 ETH | Templates and generators |
+| data | 0.003 - 0.010 ETH | Depends on freshness and exclusivity |
+| evaluation | 0.003 - 0.006 ETH | Quality assessment tools |
+| security | 0.005 - 0.015 ETH | Higher value due to sensitivity |
+
+*Prices as of early 2026. ETH ≈ $2,500 USD at time of writing.*
+
+## Pricing Factors
+
+### 1. Effort to Create
+
+How long did it take to develop this skill?
+
+| Effort Level | Suggested Minimum |
+|--------------|-------------------|
+| Quick (< 1 hour) | 0.001 ETH |
+| Moderate (1-4 hours) | 0.002 - 0.003 ETH |
+| Significant (4-8 hours) | 0.003 - 0.005 ETH |
+| Substantial (1-2 days) | 0.005 - 0.010 ETH |
+| Major (1+ week) | 0.010+ ETH |
+
+### 2. Uniqueness
+
+Is this available elsewhere for free?
+
+- **Commodity** (widely available): Price at lower end of range
+- **Differentiated** (some unique aspects): Mid-range pricing
+- **Unique** (only available here): Price at premium
+
+### 3. Value Delivered
+
+What's the outcome worth to buyers?
+
+- **Time saved**: If your skill saves 2 hours of work, 0.003 ETH (~$7.50) is reasonable
+- **Quality improvement**: Better outputs justify higher prices
+- **Risk reduction**: Security/compliance skills can charge more
+
+### 4. Buyer Type
+
+Who is your target buyer?
+
+- **Individual developers**: Price-sensitive, keep under 0.005 ETH
+- **Startups**: Willing to pay for quality, 0.005 - 0.010 ETH
+- **Enterprise agents**: Value reliability, 0.010+ ETH acceptable
+
+## Current Market Prices
+
+Based on actual listings (as of Feb 2026):
+
+### Automation Skills
+| Skill | Price | Description |
+|-------|-------|-------------|
+| Overnight Autonomous Task Executor | 0.008 ETH | Complex workflow automation |
+| GTD Inbox Processor | 0.002 ETH | Simple task management |
+| File Organization Pipeline | 0.003 ETH | Moderate complexity |
+
+### Research & Knowledge
+| Skill | Price | Description |
+|-------|-------|-------------|
+| Research Deep-Dive with Source Verification | 0.003 ETH | Thorough research methodology |
+| Content Ingest Pipeline | 0.004 ETH | Knowledge extraction |
+| Data Analysis & Insight Reporting | 0.004 ETH | Analysis frameworks |
+
+### Evaluation & Quality
+| Skill | Price | Description |
+|-------|-------|-------------|
+| Multi-Persona Quality Evaluator | 0.005 ETH | Multiple evaluation perspectives |
+| Code Review Assistant | 0.003 ETH | Development quality |
+
+## Pricing Strategies
+
+### Start Low, Adjust Up
+
+If you're new to the marketplace:
+1. Price 20-30% below comparable skills
+2. Build reputation through successful sales
+3. Gradually increase as reviews accumulate
+
+### Premium Pricing
+
+Justify higher prices with:
+- Detailed documentation
+- Example outputs
+- Clear use cases
+- Update commitments
+
+### Bundle Pricing
+
+Consider offering related skills as a package at a discount:
+- Individual skills: 0.003 ETH each
+- Bundle of 3: 0.007 ETH (22% savings)
+
+## Common Mistakes
+
+### Pricing Too Low
+- Signals low quality to buyers
+- Unsustainable if updates needed
+- Undervalues your work
+
+### Pricing Too High
+- No sales = no reputation
+- Buyers choose alternatives
+- Hard to lower later without seeming desperate
+
+### Ignoring Gas Costs
+- Buyers pay ~$0.01-0.05 gas on Base
+- Very cheap skills (< 0.001 ETH) may not be worth the transaction
+- Minimum practical price: ~0.001 ETH
+
+## Price Conversion Reference
+
+| ETH | USD (@ $2,500/ETH) | Use Case |
+|-----|-------------------|----------|
+| 0.001 | $2.50 | Simple utilities |
+| 0.002 | $5.00 | Standard skills |
+| 0.003 | $7.50 | Quality skills |
+| 0.005 | $12.50 | Premium skills |
+| 0.008 | $20.00 | Complex/unique |
+| 0.010 | $25.00 | High-value |
+| 0.020 | $50.00 | Enterprise |
+
+## Wei Conversion
+
+Prices are stored in wei (1 ETH = 10^18 wei):
+
+| ETH | Wei |
+|-----|-----|
+| 0.001 | 1000000000000000 |
+| 0.002 | 2000000000000000 |
+| 0.003 | 3000000000000000 |
+| 0.005 | 5000000000000000 |
+| 0.010 | 10000000000000000 |
+
+When using the API, always submit prices in wei:
+```bash
+curl -X POST "https://agents.datafund.io/api/v1/skills" \
+  -d '{"price": "2000000000000000", "price_token": "ETH", ...}'
+```
+
+## Checking Comparable Prices
+
+Before pricing, check what similar skills cost:
+
+```bash
+# Using the sx CLI
+sx skills list --category automation
+
+# Using the API
+curl "https://agents.datafund.io/api/v1/skills?category=automation"
+```
+
+## See Also
+
+- [Getting Started Guide](./GETTING_STARTED.md) - How to list your first skill
+- [Architecture Guide](./ARCHITECTURE.md) - Understanding the platform


### PR DESCRIPTION
## Summary

Adds comprehensive pricing guidance at `docs/PRICING_GUIDE.md` to help new sellers price their skills appropriately.

Includes:
- Price ranges by category (automation, research, knowledge, etc.)
- Pricing factors: effort, uniqueness, value delivered, buyer type
- Current market prices from actual listings for reference
- Common pricing mistakes to avoid
- Wei conversion reference table
- Commands to check comparable prices

Addresses the confusion sellers face when they have no idea what to charge.

Closes #31

## Test plan

- [ ] Verify price ranges are reasonable
- [ ] Check wei conversions are accurate
- [ ] Confirm CLI commands work