### PR TITLE
feat: x402 micropayment support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,6 @@
+[submodule "packages/contracts/sol/lib/forge-std"]
+	path = packages/contracts/sol/lib/forge-std
+	url = https://github.com/foundry-rs/forge-std
+[submodule "packages/contracts/sol/lib/openzeppelin-contracts"]
+	path = packages/contracts/sol/lib/openzeppelin-contracts
+	url = https://github.com/OpenZeppelin/openzeppelin-contracts

--- a/packages/agents-api/package.json
+++ b/packages/agents-api/package.json
@@ -15,6 +15,9 @@
     "build:cli": "tsc -p tsconfig.cli.json"
   },
   "dependencies": {
+    "@ade/contracts": "file:../contracts",
+    "@x402/core": "^2.5.0",
+    "ajv": "^8.18.0",
     "better-sqlite3": "^11.0.0",
     "commander": "^12.1.0",
     "cors": "^2.8.5",

--- a/packages/agents-api/src/api/handlers/x402-download.ts
+++ b/packages/agents-api/src/api/handlers/x402-download.ts
@@ -205,7 +205,12 @@ async function fetchAndDecryptContent(
     return { error: 'Invalid Swarm reference', status: 500 }
   }
   const swarmUrl = (SWARM_GATEWAY).replace(/\/+$/, '')
-  const swarmRes = await fetch(`${swarmUrl}/bytes/${swarmRef}`)
+  let swarmRes: Response
+  try {
+    swarmRes = await fetch(`${swarmUrl}/bytes/${swarmRef}`)
+  } catch (err) {
+    return { error: 'Failed to fetch content from Swarm', status: 502 }
+  }
   if (!swarmRes.ok) {
     return { error: 'Failed to fetch content from Swarm', status: 502 }
   }

--- a/packages/agents-api/src/api/handlers/x402-download.ts
+++ b/packages/agents-api/src/api/handlers/x402-download.ts
@@ -1,8 +1,8 @@
 import type { Request, Response } from 'express'
 import type { AgentsDatabase } from '../../db/database.js'
 import * as crypto from 'crypto'
-import { type PublicClient, type WalletClient, type Hex, keccak256, toBytes, createPublicClient, createWalletClient, http } from 'viem'
-import { base } from 'viem/chains'
+import { type Chain, type PublicClient, type WalletClient, type Hex, keccak256, toBytes, createPublicClient, createWalletClient, http } from 'viem'
+import { base, baseSepolia } from 'viem/chains'
 import { privateKeyToAccount } from 'viem/accounts'
 
 // --- Inlined from @fairdrop/agent-exchange-sdk/src/x402.ts — keep in sync ---
@@ -88,9 +88,14 @@ class PaymentProxyClient {
 
 // --- End inlined code ---
 
-// Constants
-const USDC_BASE = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'
-const BASE_NETWORK = 'eip155:8453'
+// Network configuration — fail-fast if misconfigured
+const SUPPORTED_NETWORKS: Record<string, { chain: Chain; usdc: string }> = {
+  'eip155:8453':  { chain: base, usdc: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913' },
+  'eip155:84532': { chain: baseSepolia, usdc: '0x036CbD53842c5426634e7929541eC2318f3dCF7e' },
+}
+const X402_NETWORK = process.env.X402_NETWORK || 'eip155:8453'
+const networkConfig = SUPPORTED_NETWORKS[X402_NETWORK]
+if (!networkConfig) throw new Error(`[x402] Unsupported X402_NETWORK: ${X402_NETWORK}. Supported: ${Object.keys(SUPPORTED_NETWORKS).join(', ')}`)
 
 // === Configuration (validated at startup — see Task 4b Step 3) ===
 
@@ -149,12 +154,12 @@ function create402Response(skillId: string, price: string, seller: string, resou
     x402Version: 2,
     paymentRequirements: [{
       scheme: 'exact',
-      network: BASE_NETWORK,
+      network: X402_NETWORK,
       maxAmountRequired: price,
       resource,
       description: `Purchase skill: ${skillId}`,
       payTo: PAYMENT_PROXY,
-      asset: USDC_BASE,
+      asset: networkConfig.usdc,
       extra: { seller, skillId },
     }],
   }
@@ -167,9 +172,9 @@ let proxyClient: PaymentProxyClient | null = null
 function getProxyClient(): PaymentProxyClient | null {
   if (proxyClient) return proxyClient
   if (!PAYMENT_PROXY || !RELAYER_KEY) return null
-  const pub = createPublicClient({ chain: base, transport: http() })
+  const pub = createPublicClient({ chain: networkConfig.chain, transport: http() })
   const account = privateKeyToAccount(RELAYER_KEY as `0x${string}`)
-  const wallet = createWalletClient({ chain: base, transport: http(), account })
+  const wallet = createWalletClient({ chain: networkConfig.chain, transport: http(), account })
   proxyClient = new PaymentProxyClient(PAYMENT_PROXY as `0x${string}`, pub as PublicClient, wallet as WalletClient)
   return proxyClient
 }
@@ -186,7 +191,7 @@ async function forwardPaymentToSeller(
   }
   try {
     const txHash = await client.forward(
-      seller as `0x${string}`, USDC_BASE as `0x${string}`, BigInt(amount), skillId
+      seller as `0x${string}`, networkConfig.usdc as `0x${string}`, BigInt(amount), skillId
     )
     db.updatePendingForward(paymentId, 'completed', txHash)
     console.error(`[x402] Forwarded ${amount} USDC to ${seller}: ${txHash}`)

--- a/packages/agents-api/src/api/handlers/x402-download.ts
+++ b/packages/agents-api/src/api/handlers/x402-download.ts
@@ -295,6 +295,13 @@ export function x402DownloadHandler(db: AgentsDatabase) {
       // Invalid tx_hash — fall through to normal payment flow
     }
 
+    // Validate content exists BEFORE accepting payment — don't take money for undeliverable content
+    const swarmRef = skill.encrypted_data_ref
+    if (!swarmRef || !isValidSwarmRef(swarmRef)) {
+      res.status(404).json({ error: 'Skill has no downloadable content' })
+      return
+    }
+
     const paymentHeader = (req.headers['x-payment'] || req.headers['payment-signature']) as string
 
     if (!paymentHeader) {
@@ -342,13 +349,7 @@ export function x402DownloadHandler(db: AgentsDatabase) {
     forwardPaymentToSeller(db, skill.seller, price, req.params.id, paymentId)
       .catch(err => console.error(`[x402] Forward failed for payment ${paymentId}:`, err.message))
 
-    // Fetch and decrypt content
-    const swarmRef = skill.encrypted_data_ref
-    if (!swarmRef) {
-      res.status(404).json({ error: 'No content reference' })
-      return
-    }
-
+    // Fetch and decrypt content (swarmRef already validated above)
     try {
       const result = await fetchAndDecryptContent(swarmRef, skill.x402_content_key, CONTENT_KEY_SECRET)
       if ('error' in result) {

--- a/packages/agents-api/src/api/handlers/x402-download.ts
+++ b/packages/agents-api/src/api/handlers/x402-download.ts
@@ -1,0 +1,375 @@
+import type { Request, Response } from 'express'
+import type { AgentsDatabase } from '../../db/database.js'
+import * as crypto from 'crypto'
+import { type PublicClient, type WalletClient, type Hex, keccak256, toBytes, createPublicClient, createWalletClient, http } from 'viem'
+import { base } from 'viem/chains'
+import { privateKeyToAccount } from 'viem/accounts'
+
+// --- Inlined from @fairdrop/agent-exchange-sdk/src/x402.ts — keep in sync ---
+
+function decryptContentKey(encrypted: string, masterSecretHex: string): string {
+  const master = Buffer.from(masterSecretHex, 'hex')
+  const buf = Buffer.from(encrypted, 'base64')
+  const iv = buf.subarray(0, 12)
+  const tag = buf.subarray(12, 28)
+  const ct = buf.subarray(28)
+  const decipher = crypto.createDecipheriv('aes-256-gcm', master, iv)
+  decipher.setAuthTag(tag)
+  return decipher.update(ct).toString('utf8') + decipher.final('utf8')
+}
+
+function decryptContent(encrypted: Buffer, keyHex: string): Buffer {
+  const key = Buffer.from(keyHex, 'hex')
+  const iv = encrypted.subarray(0, 12)
+  const authTag = encrypted.subarray(12, 28)
+  const ciphertext = encrypted.subarray(28)
+  const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv)
+  decipher.setAuthTag(authTag)
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()])
+}
+
+function sanitizeFilename(name: string): string {
+  const cleaned = name
+    .replace(/[^a-zA-Z0-9._-]/g, '')
+    .replace(/\.{2,}/g, '.')
+    .replace(/^\.+/, '')
+    .trim()
+  return cleaned || 'download'
+}
+
+function isValidSwarmRef(ref: string): boolean {
+  return /^[0-9a-f]{64}$/i.test(ref)
+}
+
+// --- Inlined PaymentProxyClient (from packages/contracts/src/PaymentProxy.ts) — keep in sync ---
+
+const PAYMENT_PROXY_ABI = [
+  {
+    name: 'forward',
+    type: 'function',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'seller', type: 'address' },
+      { name: 'token', type: 'address' },
+      { name: 'amount', type: 'uint256' },
+      { name: 'skillId', type: 'bytes32' },
+    ],
+    outputs: [],
+  },
+  {
+    name: 'feeBps',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [{ type: 'uint16' }],
+  },
+] as const
+
+class PaymentProxyClient {
+  constructor(
+    private address: Hex,
+    private pub: PublicClient,
+    private wallet?: WalletClient,
+  ) {}
+
+  async forward(seller: Hex, token: Hex, amount: bigint, skillId: string): Promise<Hex> {
+    if (!this.wallet?.account) throw new Error('Wallet required for forward()')
+    const skillIdBytes32 = keccak256(toBytes(skillId))
+    const { request } = await this.pub.simulateContract({
+      address: this.address,
+      abi: PAYMENT_PROXY_ABI,
+      functionName: 'forward',
+      args: [seller, token, amount, skillIdBytes32],
+      account: this.wallet.account,
+    })
+    return this.wallet.writeContract(request)
+  }
+}
+
+// --- End inlined code ---
+
+// Constants
+const USDC_BASE = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'
+const BASE_NETWORK = 'eip155:8453'
+
+// === Configuration (validated at startup — see Task 4b Step 3) ===
+
+const FACILITATOR_URL = process.env.X402_FACILITATOR_URL || 'https://x402.org/facilitator'
+const PAYMENT_PROXY = process.env.PAYMENT_PROXY_ADDRESS || ''
+const RELAYER_KEY = process.env.RELAYER_KEY || ''
+const CONTENT_KEY_SECRET = process.env.X402_CONTENT_KEY_SECRET || ''
+const SWARM_GATEWAY = process.env.SWARM_GATEWAY_URL || 'https://bee.fairdrop.xyz'
+
+// === Facilitator client ===
+
+interface SettlementResult {
+  success: boolean
+  txHash?: string
+  buyerAddress?: string
+  settledAmount?: string
+  error?: string
+}
+
+async function verifyAndSettle(paymentHeader: string, expectedAmount: string): Promise<SettlementResult> {
+  try {
+    const res = await fetch(`${FACILITATOR_URL}/settle`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ payment: paymentHeader }),
+    })
+    if (!res.ok) {
+      return { success: false, error: `Facilitator: ${res.status}` }
+    }
+    const data = await res.json() as any
+    const txHash = data.txHash || data.transaction?.hash
+    const buyerAddress = data.payerAddress || data.from
+    const settledAmount = data.amount || data.value
+
+    if (!txHash || !/^0x[0-9a-f]{64}$/i.test(txHash)) {
+      return { success: false, error: 'Invalid txHash format from facilitator' }
+    }
+    if (!buyerAddress) {
+      return { success: false, error: 'No buyer address from facilitator' }
+    }
+    if (!settledAmount) {
+      return { success: false, error: 'Facilitator did not return settled amount — cannot verify payment' }
+    }
+    if (BigInt(settledAmount) < BigInt(expectedAmount)) {
+      return { success: false, error: `Underpayment: settled ${settledAmount} but skill costs ${expectedAmount}` }
+    }
+
+    return { success: true, txHash, buyerAddress, settledAmount }
+  } catch (err) {
+    return { success: false, error: (err as Error).message }
+  }
+}
+
+function create402Response(skillId: string, price: string, seller: string, resource: string) {
+  return {
+    x402Version: 2,
+    paymentRequirements: [{
+      scheme: 'exact',
+      network: BASE_NETWORK,
+      maxAmountRequired: price,
+      resource,
+      description: `Purchase skill: ${skillId}`,
+      payTo: PAYMENT_PROXY,
+      asset: USDC_BASE,
+      extra: { seller, skillId },
+    }],
+  }
+}
+
+// === Proxy forward ===
+
+let proxyClient: PaymentProxyClient | null = null
+
+function getProxyClient(): PaymentProxyClient | null {
+  if (proxyClient) return proxyClient
+  if (!PAYMENT_PROXY || !RELAYER_KEY) return null
+  const pub = createPublicClient({ chain: base, transport: http() })
+  const account = privateKeyToAccount(RELAYER_KEY as `0x${string}`)
+  const wallet = createWalletClient({ chain: base, transport: http(), account })
+  proxyClient = new PaymentProxyClient(PAYMENT_PROXY as `0x${string}`, pub as PublicClient, wallet as WalletClient)
+  return proxyClient
+}
+
+async function forwardPaymentToSeller(
+  db: AgentsDatabase, seller: string, amount: string, skillId: string, paymentId: string
+): Promise<void> {
+  db.recordPendingForward({ paymentId, skillId, seller, amount })
+
+  const client = getProxyClient()
+  if (!client) {
+    console.error('[x402] No proxy client configured — forward stays pending in DB')
+    return
+  }
+  try {
+    const txHash = await client.forward(
+      seller as `0x${string}`, USDC_BASE as `0x${string}`, BigInt(amount), skillId
+    )
+    db.updatePendingForward(paymentId, 'completed', txHash)
+    console.error(`[x402] Forwarded ${amount} USDC to ${seller}: ${txHash}`)
+  } catch (err) {
+    db.updatePendingForward(paymentId, 'failed', undefined)
+    console.error(`[x402] Forward failed for skill ${skillId} seller ${seller}:`, err)
+  }
+}
+
+// === Shared: fetch and decrypt content from Swarm ===
+
+async function fetchAndDecryptContent(
+  swarmRef: string, encryptedKey: string | null, contentKeySecret: string
+): Promise<{ content: Buffer } | { error: string; status: number }> {
+  if (!isValidSwarmRef(swarmRef)) {
+    return { error: 'Invalid Swarm reference', status: 500 }
+  }
+  const swarmUrl = (SWARM_GATEWAY).replace(/\/+$/, '')
+  const swarmRes = await fetch(`${swarmUrl}/bytes/${swarmRef}`)
+  if (!swarmRes.ok) {
+    return { error: 'Failed to fetch content from Swarm', status: 502 }
+  }
+  let content: Buffer = Buffer.from(await swarmRes.arrayBuffer())
+  if (encryptedKey && contentKeySecret) {
+    const contentKey = decryptContentKey(encryptedKey, contentKeySecret)
+    content = decryptContent(content, contentKey) as Buffer
+  }
+  return { content }
+}
+
+// === Export: x402 download handler ===
+
+export function x402DownloadHandler(db: AgentsDatabase) {
+  return async (req: Request, res: Response) => {
+    const skill = db.getSkill(req.params.id)
+    if (!skill) {
+      res.status(404).json({ error: 'Skill not found' })
+      return
+    }
+
+    const price = skill.price ?? '0'
+    const paymentMethod = skill.payment_method ?? 'escrow'
+
+    // --- Free download (existing behavior) ---
+    if (paymentMethod === 'free' || price === '0' || price === '') {
+      const escrow = db.getAvailableEscrowForSkill(req.params.id)
+      if (escrow) {
+        res.status(403).json({ error: 'Skill has active escrow. Use purchase-info endpoint.' })
+        return
+      }
+      const swarmRef = skill.encrypted_data_ref
+      if (!swarmRef || !isValidSwarmRef(swarmRef)) {
+        res.status(404).json({ error: 'No content reference available' })
+        return
+      }
+      const swarmUrl = (SWARM_GATEWAY).replace(/\/+$/, '')
+      res.redirect(`${swarmUrl}/bytes/${swarmRef}`)
+      return
+    }
+
+    // --- Escrow-gated (existing behavior) ---
+    if (paymentMethod === 'escrow') {
+      res.status(403).json({
+        error: 'Paid skills require escrow-based download. Use purchase-info endpoint.',
+      })
+      return
+    }
+
+    // --- x402 paywall ---
+
+    // Re-download support: buyer provides tx_hash + X-Buyer-Address header
+    const redownloadTxHash = req.query.tx_hash as string
+    if (redownloadTxHash) {
+      const existing = db.getX402PaymentByTxHash(redownloadTxHash)
+      if (existing && existing.skill_id === req.params.id) {
+        const claimedBuyer = (req.headers['x-buyer-address'] as string || '').toLowerCase()
+        if (!claimedBuyer) {
+          res.status(401).json({
+            error: 'X-Buyer-Address header required for re-download',
+            hint: 'Set header to the wallet address that made the original purchase',
+          })
+          return
+        }
+        if (claimedBuyer !== existing.buyer_address.toLowerCase()) {
+          res.status(403).json({ error: 'Buyer address does not match payment record' })
+          return
+        }
+        const result = await fetchAndDecryptContent(
+          skill.encrypted_data_ref, skill.x402_content_key, CONTENT_KEY_SECRET
+        )
+        if ('error' in result) {
+          res.status(result.status).json({ error: result.error })
+          return
+        }
+        const contentFormat = skill.product_type
+          ? (db.getProductType(skill.product_type)?.content_format || 'bin')
+          : 'bin'
+        const ext = contentFormat === 'tar.gz' ? '.tar.gz' : `.${contentFormat}`
+        const filename = sanitizeFilename(skill.title || 'download') + ext
+        res.set('Content-Type', 'application/octet-stream')
+        res.set('Content-Disposition', `attachment; filename="${filename}"`)
+        res.set('X-Payment-TxHash', existing.tx_hash)
+        res.send(result.content)
+        return
+      }
+      // Invalid tx_hash — fall through to normal payment flow
+    }
+
+    const paymentHeader = (req.headers['x-payment'] || req.headers['payment-signature']) as string
+
+    if (!paymentHeader) {
+      res.status(402).json(create402Response(
+        req.params.id, price, skill.seller, req.originalUrl
+      ))
+      return
+    }
+
+    // Verify and settle payment via Coinbase facilitator
+    const settlement = await verifyAndSettle(paymentHeader, price)
+    if (!settlement.success) {
+      res.status(402).json({
+        error: 'Payment verification failed',
+        details: settlement.error,
+        ...create402Response(req.params.id, price, skill.seller, req.originalUrl),
+      })
+      return
+    }
+
+    const paymentId = `x402-${Date.now()}-${crypto.randomBytes(16).toString('hex')}`
+
+    // Record payment (returns false on duplicate tx_hash)
+    const recorded = db.recordX402Payment({
+      id: paymentId,
+      skillId: req.params.id,
+      buyerAddress: settlement.buyerAddress!,
+      sellerAddress: skill.seller,
+      amount: price,
+      fee: '0',
+      txHash: settlement.txHash!,
+      settledAt: Math.floor(Date.now() / 1000),
+    })
+    if (!recorded) {
+      res.status(409).json({
+        error: 'Payment already processed',
+        hint: `Re-download: GET /skills/${req.params.id}/download?tx_hash=${settlement.txHash}`,
+      })
+      return
+    }
+
+    db.incrementSkillSales(req.params.id)
+
+    // Forward payment from proxy to seller (async, non-blocking)
+    forwardPaymentToSeller(db, skill.seller, price, req.params.id, paymentId)
+      .catch(err => console.error(`[x402] Forward failed for payment ${paymentId}:`, err.message))
+
+    // Fetch and decrypt content
+    const swarmRef = skill.encrypted_data_ref
+    if (!swarmRef) {
+      res.status(404).json({ error: 'No content reference' })
+      return
+    }
+
+    try {
+      const result = await fetchAndDecryptContent(swarmRef, skill.x402_content_key, CONTENT_KEY_SECRET)
+      if ('error' in result) {
+        res.status(result.status).json({ error: result.error })
+        return
+      }
+      const contentFormat = skill.product_type
+        ? (db.getProductType(skill.product_type)?.content_format || 'bin')
+        : 'bin'
+      const ext = contentFormat === 'tar.gz' ? '.tar.gz' : `.${contentFormat}`
+      const filename = sanitizeFilename(skill.title || 'download') + ext
+      res.set('Content-Type', 'application/octet-stream')
+      res.set('Content-Disposition', `attachment; filename="${filename}"`)
+      res.set('X-Payment-TxHash', settlement.txHash!)
+      res.send(result.content)
+    } catch (err) {
+      console.error('[x402] Content delivery error:', err)
+      res.status(502).json({
+        error: 'Content delivery failed after payment',
+        hint: `Re-download: GET /skills/${req.params.id}/download?tx_hash=${settlement.txHash}`,
+      })
+    }
+  }
+}

--- a/packages/agents-api/src/api/routes/skills.ts
+++ b/packages/agents-api/src/api/routes/skills.ts
@@ -1,30 +1,82 @@
 import { Router } from 'express'
 import { randomUUID } from 'crypto'
 import type { AgentsDatabase } from '../../db/database.js'
+import type { SkillRow } from '../../db/database.js'
 import { sanitize, isValidAddress, verifyWalletSignature } from '../sanitize.js'
 import { scoreTier, scoreRecommendation } from '../../reputation/calculator.js'
+import { verifySignature } from '../middleware/verify-signature.js'
 
 const ESCROW_CONTRACT = '0xDd4396d4F28d2b513175ae17dE11e56a898d19c3'
 const CHAIN_ID = 8453
 
+function sanitizeSkill(skill: SkillRow): Record<string, unknown> {
+  const { x402_content_key, ...rest } = skill as any
+  if (rest.payment_method === 'x402') {
+    delete rest.encrypted_data_ref
+  }
+  return rest
+}
+
 export function skillRoutes(db: AgentsDatabase): Router {
   const router = Router()
 
-  // POST /skills — list a skill for sale
-  router.post('/', (req, res) => {
-    const { seller, sellerAgentId, title, description, longDescription, category, price, priceToken, tags, delivery, contentHash, encryptedDataRef, escrowId } = req.body
+  // POST /skills — list a skill for sale (requires EIP-191 signature)
+  router.post('/', verifySignature, async (req, res) => {
+    const { seller, sellerAgentId, title, description, longDescription, category, price, priceToken, tags, delivery, contentHash, encryptedDataRef, escrowId, product_type, metadata, payment_method, x402_content_key } = req.body
 
     if (!isValidAddress(seller) || !title) {
       res.status(400).json({ error: 'valid seller address and title are required' })
       return
     }
 
+    // Validate payment_method enum
+    const validPaymentMethods = ['escrow', 'x402']
+    if (payment_method && !validPaymentMethods.includes(payment_method)) {
+      res.status(400).json({ error: `Invalid payment_method: ${payment_method}. Must be one of: ${validPaymentMethods.join(', ')}` })
+      return
+    }
+
+    // Validate x402_content_key format (64 hex chars, not all zeros)
+    if (x402_content_key) {
+      if (!/^[0-9a-fA-F]{64}$/.test(x402_content_key)) {
+        res.status(400).json({ error: 'x402_content_key must be exactly 64 hex characters' })
+        return
+      }
+      if (/^0+$/.test(x402_content_key)) {
+        res.status(400).json({ error: 'x402_content_key must not be all zeros' })
+        return
+      }
+    }
+
+    // Validate product_type metadata if provided
+    if (product_type) {
+      const productType = db.getProductType(product_type)
+      if (!productType) {
+        res.status(400).json({ error: `Unknown product_type: ${product_type}` })
+        return
+      }
+      // Validate metadata against the type's JSON Schema
+      if (productType.schema) {
+        const validationError = db.validateMetadata(metadata, productType.schema)
+        if (validationError) {
+          res.status(400).json({ error: `Invalid metadata for product_type "${product_type}": ${validationError}` })
+          return
+        }
+      }
+    }
+
     const id = randomUUID()
     const now = Math.floor(Date.now() / 1000)
 
+    // Use verified address from signature middleware as seller
+    const verifiedSeller = (req as any).verifiedAddress || seller
+
     const created = db.createSkill({
-      id, seller, sellerAgentId, title: sanitize(title), description: sanitize(description), longDescription: sanitize(longDescription),
-      category: sanitize(category), price, priceToken, tags, delivery: sanitize(delivery), contentHash, encryptedDataRef, createdAt: now,
+      id, seller: verifiedSeller, sellerAgentId, title: sanitize(title), description: sanitize(description), longDescription: sanitize(longDescription),
+      category: sanitize(category), price, priceToken, tags, delivery: sanitize(delivery), contentHash, encryptedDataRef,
+      productType: product_type, metadata: metadata ? JSON.stringify(metadata) : undefined,
+      paymentMethod: payment_method, x402ContentKey: x402_content_key,
+      createdAt: now,
     })
 
     if (!created) {
@@ -41,21 +93,23 @@ export function skillRoutes(db: AgentsDatabase): Router {
       }
     }
 
-    res.status(201).json({ id, seller: seller.toLowerCase(), title, status: 'active', escrowId: escrowId ?? null, createdAt: now })
+    res.status(201).json({ id, seller: verifiedSeller.toLowerCase(), title, status: 'active', escrowId: escrowId ?? null, product_type: product_type ?? null, payment_method: payment_method ?? 'escrow', createdAt: now })
   })
 
   // GET /skills — list skills with availability status
   router.get('/', (req, res) => {
-    const { seller, category, status, limit, offset } = req.query
+    const { seller, category, status, limit, offset, product_type, payment_method } = req.query
 
     const skills = db.listSkills({
       seller: seller as string,
       category: category as string,
       status: (status as string) ?? 'active',
+      productType: product_type as string,
+      paymentMethod: payment_method as string,
       limit: limit ? Number(limit) : 50,
       offset: offset ? Number(offset) : 0,
     })
-    const total = db.countSkills({ seller: seller as string, category: category as string, status: (status as string) ?? 'active' })
+    const total = db.countSkills({ seller: seller as string, category: category as string, status: (status as string) ?? 'active', productType: product_type as string, paymentMethod: payment_method as string })
 
     // Batch query for availability to avoid N+1 queries
     const skillIds = skills.map(s => s.id)
@@ -87,8 +141,9 @@ export function skillRoutes(db: AgentsDatabase): Router {
         availability = 'not_listed'
       }
       const sellerRep = sellerRepMap.get(s.seller)
+      const sanitized = sanitizeSkill(s)
       return {
-        ...s,
+        ...sanitized,
         tags: JSON.parse(s.tags),
         availability,
         available_copies: avail.available,
@@ -111,7 +166,8 @@ export function skillRoutes(db: AgentsDatabase): Router {
     }
     const votes = db.getVoteSummary('skill', req.params.id)
     const commentCount = db.countComments('skill', req.params.id)
-    res.json({ ...skill, tags: JSON.parse(skill.tags), votes, commentCount })
+    const sanitized = sanitizeSkill(skill)
+    res.json({ ...sanitized, tags: JSON.parse(skill.tags), votes, commentCount })
   })
 
   // POST /skills/:id/vote — vote on a skill
@@ -161,6 +217,9 @@ export function skillRoutes(db: AgentsDatabase): Router {
       return
     }
 
+    // Strip encrypted_data_ref for x402 skills
+    const safeDataRef = skill.payment_method === 'x402' ? undefined : (skill.encrypted_data_ref || '')
+
     // Find the next available escrow for this skill (multi-copy support)
     const escrow = db.getAvailableEscrowForSkill(req.params.id)
 
@@ -177,7 +236,7 @@ export function skillRoutes(db: AgentsDatabase): Router {
 
       const available = db.countAvailableEscrows(req.params.id)
 
-      res.json({
+      const purchaseInfo: Record<string, unknown> = {
         status: 'purchasable',
         escrow_id: escrow.id,
         escrow_state: escrow.state,
@@ -189,14 +248,15 @@ export function skillRoutes(db: AgentsDatabase): Router {
         chain_id: CHAIN_ID,
         available_copies: available,
         total_sales: skill.total_sales,
-        encrypted_data_ref: skill.encrypted_data_ref || '',
         fund_call: {
           function: 'fundEscrow(uint256,uint256)',
           args: [escrow.id, 0],
           value_wei: escrow.payment_token === '0x0000000000000000000000000000000000000000' ? escrow.amount : '0',
           note: 'For ERC20 tokens, approve() the contract first for the amount',
         },
-      })
+      }
+      if (safeDataRef !== undefined) purchaseInfo.encrypted_data_ref = safeDataRef
+      res.json(purchaseInfo)
       return
     }
 
@@ -205,25 +265,59 @@ export function skillRoutes(db: AgentsDatabase): Router {
 
     // Distinguish between "sold out" (had escrows, all consumed) vs "not listed" (never had escrows)
     if (allEscrows.length === 0) {
-      res.json({
+      const notListed: Record<string, unknown> = {
         status: 'not_listed',
         seller: skill.seller,
         content_hash: skill.content_hash,
-        encrypted_data_ref: skill.encrypted_data_ref || '',
         total_sales: skill.total_sales,
         note: 'No escrow created yet. Poll this endpoint or create a bounty.',
-      })
+      }
+      if (safeDataRef !== undefined) notListed.encrypted_data_ref = safeDataRef
+      res.json(notListed)
       return
     }
 
-    res.json({
+    const soldOut: Record<string, unknown> = {
       status: 'sold_out',
       seller: skill.seller,
       content_hash: skill.content_hash,
-      encrypted_data_ref: skill.encrypted_data_ref || '',
       total_sales: skill.total_sales,
       note: 'All copies sold. Check back later or contact seller.',
-    })
+    }
+    if (safeDataRef !== undefined) soldOut.encrypted_data_ref = safeDataRef
+    res.json(soldOut)
+  })
+
+  // GET /skills/:id/download — free download redirect for unencrypted packs
+  router.get('/:id/download', (req, res) => {
+    const skill = db.getSkill(req.params.id)
+    if (!skill) {
+      res.status(404).json({ error: 'Skill not found' })
+      return
+    }
+
+    // Only allow download for free skills (price "0" or empty) without active escrow
+    const price = skill.price ?? '0'
+    if (price !== '0' && price !== '') {
+      res.status(403).json({ error: 'Paid skills require escrow-based download. Use purchase-info endpoint.' })
+      return
+    }
+
+    const escrow = db.getAvailableEscrowForSkill(req.params.id)
+    if (escrow) {
+      res.status(403).json({ error: 'Skill has active escrow. Use purchase-info endpoint.' })
+      return
+    }
+
+    // encryptedDataRef holds the Swarm reference (unencrypted for free packs)
+    const swarmRef = skill.encrypted_data_ref
+    if (!swarmRef) {
+      res.status(404).json({ error: 'No content reference available for this skill' })
+      return
+    }
+
+    const swarmUrl = process.env.SWARM_GATEWAY_URL || 'https://bee.fairdrop.xyz'
+    res.redirect(`${swarmUrl}/bytes/${swarmRef}`)
   })
 
   return router

--- a/packages/agents-api/src/api/routes/skills.ts
+++ b/packages/agents-api/src/api/routes/skills.ts
@@ -5,9 +5,16 @@ import type { SkillRow } from '../../db/database.js'
 import { sanitize, isValidAddress, verifyWalletSignature } from '../sanitize.js'
 import { scoreTier, scoreRecommendation } from '../../reputation/calculator.js'
 import { verifySignature } from '../middleware/verify-signature.js'
+import { x402DownloadHandler } from '../handlers/x402-download.js'
+import { createRateLimit } from '../middleware/rate-limit.js'
 
 const ESCROW_CONTRACT = '0xDd4396d4F28d2b513175ae17dE11e56a898d19c3'
 const CHAIN_ID = 8453
+
+const downloadRateLimit = createRateLimit({
+  windowMs: 60_000,
+  maxRequests: 10,
+})
 
 function sanitizeSkill(skill: SkillRow): Record<string, unknown> {
   const { x402_content_key, ...rest } = skill as any
@@ -157,6 +164,29 @@ export function skillRoutes(db: AgentsDatabase): Router {
     })
   })
 
+  // GET /skills/x402-payments — list x402 payments for authenticated seller
+  router.get('/x402-payments', verifySignature, (req, res) => {
+    const limit = parseInt(req.query.limit as string) || 20
+    const address = (req as any).verifiedAddress
+    if (!address) {
+      res.status(401).json({ error: 'Signature authentication required' })
+      return
+    }
+    const payments = db.listX402PaymentsBySeller(address, limit)
+    res.json(payments)
+  })
+
+  // GET /skills/x402-payments/pending-forwards — list pending forwards for authenticated seller
+  router.get('/x402-payments/pending-forwards', verifySignature, (req, res) => {
+    const address = (req as any).verifiedAddress
+    if (!address) {
+      res.status(401).json({ error: 'Signature authentication required' })
+      return
+    }
+    const forwards = db.getPendingForwardsBySeller(address)
+    res.json(forwards)
+  })
+
   // GET /skills/:id — get single skill with votes
   router.get('/:id', (req, res) => {
     const skill = db.getSkill(req.params.id)
@@ -288,37 +318,8 @@ export function skillRoutes(db: AgentsDatabase): Router {
     res.json(soldOut)
   })
 
-  // GET /skills/:id/download — free download redirect for unencrypted packs
-  router.get('/:id/download', (req, res) => {
-    const skill = db.getSkill(req.params.id)
-    if (!skill) {
-      res.status(404).json({ error: 'Skill not found' })
-      return
-    }
-
-    // Only allow download for free skills (price "0" or empty) without active escrow
-    const price = skill.price ?? '0'
-    if (price !== '0' && price !== '') {
-      res.status(403).json({ error: 'Paid skills require escrow-based download. Use purchase-info endpoint.' })
-      return
-    }
-
-    const escrow = db.getAvailableEscrowForSkill(req.params.id)
-    if (escrow) {
-      res.status(403).json({ error: 'Skill has active escrow. Use purchase-info endpoint.' })
-      return
-    }
-
-    // encryptedDataRef holds the Swarm reference (unencrypted for free packs)
-    const swarmRef = skill.encrypted_data_ref
-    if (!swarmRef) {
-      res.status(404).json({ error: 'No content reference available for this skill' })
-      return
-    }
-
-    const swarmUrl = process.env.SWARM_GATEWAY_URL || 'https://bee.fairdrop.xyz'
-    res.redirect(`${swarmUrl}/bytes/${swarmRef}`)
-  })
+  // GET /skills/:id/download — unified download (free redirect / x402 paywall / escrow deny)
+  router.get('/:id/download', downloadRateLimit, x402DownloadHandler(db))
 
   return router
 }

--- a/packages/agents-api/src/api/routes/skills.ts
+++ b/packages/agents-api/src/api/routes/skills.ts
@@ -166,7 +166,7 @@ export function skillRoutes(db: AgentsDatabase): Router {
 
   // GET /skills/x402-payments — list x402 payments for authenticated seller
   router.get('/x402-payments', verifySignature, (req, res) => {
-    const limit = parseInt(req.query.limit as string) || 20
+    const limit = Math.min(parseInt(req.query.limit as string) || 20, 100)
     const address = (req as any).verifiedAddress
     if (!address) {
       res.status(401).json({ error: 'Signature authentication required' })

--- a/packages/agents-api/src/db/database.ts
+++ b/packages/agents-api/src/db/database.ts
@@ -673,14 +673,15 @@ export class AgentsDatabase {
     x402ContentKey?: string
     createdAt: number
   }): boolean {
-    try {
-      let encryptedKey: string | null = null
-      if (skill.x402ContentKey) {
-        const secret = process.env.X402_CONTENT_KEY_SECRET
-        if (!secret) throw new Error('X402_CONTENT_KEY_SECRET not set')
-        encryptedKey = encryptContentKey(skill.x402ContentKey, secret)
-      }
+    // Encryption config errors must fail loudly (not silently swallowed by catch below)
+    let encryptedKey: string | null = null
+    if (skill.x402ContentKey) {
+      const secret = process.env.X402_CONTENT_KEY_SECRET
+      if (!secret) throw new Error('X402_CONTENT_KEY_SECRET not set')
+      encryptedKey = encryptContentKey(skill.x402ContentKey, secret)
+    }
 
+    try {
       this.db.prepare(
         `INSERT INTO skills (id, seller, seller_agent_id, title, description, long_description, category, price, price_token, tags, delivery, content_hash, encrypted_data_ref, product_type, metadata, payment_method, x402_content_key, created_at)
          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
@@ -829,15 +830,19 @@ export class AgentsDatabase {
     txHash: string
     settledAt: number
   }): boolean {
-    this.db.prepare(
-      `INSERT INTO x402_payments (id, skill_id, buyer_address, seller_address, amount, fee, tx_hash, settled_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
-    ).run(
-      payment.id, payment.skillId, payment.buyerAddress.toLowerCase(),
-      payment.sellerAddress.toLowerCase(), payment.amount, payment.fee,
-      payment.txHash, payment.settledAt,
-    )
-    return true
+    try {
+      this.db.prepare(
+        `INSERT INTO x402_payments (id, skill_id, buyer_address, seller_address, amount, fee, tx_hash, settled_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+      ).run(
+        payment.id, payment.skillId, payment.buyerAddress.toLowerCase(),
+        payment.sellerAddress.toLowerCase(), payment.amount, payment.fee,
+        payment.txHash, payment.settledAt,
+      )
+      return true
+    } catch {
+      return false
+    }
   }
 
   listX402Payments(skillId: string): any[] {

--- a/packages/agents-api/src/db/database.ts
+++ b/packages/agents-api/src/db/database.ts
@@ -3,10 +3,21 @@
  */
 
 import Database from 'better-sqlite3'
+import Ajv from 'ajv'
+import * as crypto from 'crypto'
 import { readFileSync } from 'fs'
 import { mkdirSync } from 'fs'
 import { dirname, join } from 'path'
 import { fileURLToPath } from 'url'
+
+function encryptContentKey(keyHex: string, masterSecretHex: string): string {
+  const master = Buffer.from(masterSecretHex, 'hex')
+  const iv = crypto.randomBytes(12)
+  const cipher = crypto.createCipheriv('aes-256-gcm', master, iv)
+  const ct = Buffer.concat([cipher.update(keyHex, 'utf8'), cipher.final()])
+  const tag = cipher.getAuthTag()
+  return Buffer.concat([iv, tag, ct]).toString('base64')
+}
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
@@ -43,6 +54,57 @@ export class AgentsDatabase {
     if (!skillCols.some(c => c.name === 'encrypted_data_ref')) {
       this.db.exec("ALTER TABLE skills ADD COLUMN encrypted_data_ref TEXT DEFAULT ''")
     }
+    // Add product_type and metadata columns for data product type registry
+    if (!skillCols.some(c => c.name === 'product_type')) {
+      this.db.exec("ALTER TABLE skills ADD COLUMN product_type TEXT")
+      this.db.exec('CREATE INDEX IF NOT EXISTS idx_skills_product_type ON skills(product_type)')
+    }
+    if (!skillCols.some(c => c.name === 'metadata')) {
+      this.db.exec("ALTER TABLE skills ADD COLUMN metadata TEXT")
+    }
+
+    // x402 payment method and encrypted content key
+    const x402Cols = this.db.pragma('table_info(skills)') as Array<{ name: string }>
+
+    if (!x402Cols.some(c => c.name === 'payment_method')) {
+      this.db.exec("ALTER TABLE skills ADD COLUMN payment_method TEXT NOT NULL DEFAULT 'escrow'")
+      this.db.exec('CREATE INDEX IF NOT EXISTS idx_skills_payment_method ON skills(payment_method)')
+    }
+    if (!x402Cols.some(c => c.name === 'x402_content_key')) {
+      this.db.exec("ALTER TABLE skills ADD COLUMN x402_content_key TEXT")
+    }
+
+    // x402_payments table
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS x402_payments (
+        id TEXT PRIMARY KEY,
+        skill_id TEXT NOT NULL,
+        buyer_address TEXT NOT NULL,
+        seller_address TEXT NOT NULL,
+        amount TEXT NOT NULL,
+        fee TEXT NOT NULL DEFAULT '0',
+        tx_hash TEXT NOT NULL UNIQUE,
+        settled_at INTEGER NOT NULL,
+        FOREIGN KEY (skill_id) REFERENCES skills(id)
+      )
+    `)
+    this.db.exec('CREATE INDEX IF NOT EXISTS idx_x402_payments_skill ON x402_payments(skill_id)')
+    this.db.exec('CREATE INDEX IF NOT EXISTS idx_x402_payments_buyer ON x402_payments(buyer_address)')
+
+    // pending_forwards table
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS pending_forwards (
+        payment_id TEXT PRIMARY KEY,
+        skill_id TEXT NOT NULL,
+        seller TEXT NOT NULL,
+        amount TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'pending',
+        forward_tx_hash TEXT,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER,
+        FOREIGN KEY (payment_id) REFERENCES x402_payments(id)
+      )
+    `)
   }
 
   // === Monitor State ===
@@ -605,18 +667,31 @@ export class AgentsDatabase {
     delivery?: string
     contentHash?: string
     encryptedDataRef?: string
+    productType?: string
+    metadata?: string
+    paymentMethod?: string
+    x402ContentKey?: string
     createdAt: number
   }): boolean {
     try {
+      let encryptedKey: string | null = null
+      if (skill.x402ContentKey) {
+        const secret = process.env.X402_CONTENT_KEY_SECRET
+        if (!secret) throw new Error('X402_CONTENT_KEY_SECRET not set')
+        encryptedKey = encryptContentKey(skill.x402ContentKey, secret)
+      }
+
       this.db.prepare(
-        `INSERT INTO skills (id, seller, seller_agent_id, title, description, long_description, category, price, price_token, tags, delivery, content_hash, encrypted_data_ref, created_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        `INSERT INTO skills (id, seller, seller_agent_id, title, description, long_description, category, price, price_token, tags, delivery, content_hash, encrypted_data_ref, product_type, metadata, payment_method, x402_content_key, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
       ).run(
         skill.id, skill.seller.toLowerCase(), skill.sellerAgentId ?? 0,
         skill.title, skill.description ?? '', skill.longDescription ?? '',
         skill.category ?? '', skill.price ?? '0', skill.priceToken ?? 'ETH',
         JSON.stringify(skill.tags ?? []), skill.delivery ?? 'instant',
-        skill.contentHash ?? '', skill.encryptedDataRef ?? '', skill.createdAt,
+        skill.contentHash ?? '', skill.encryptedDataRef ?? '',
+        skill.productType ?? null, skill.metadata ?? null,
+        skill.paymentMethod ?? 'escrow', encryptedKey, skill.createdAt,
       )
       return true
     } catch {
@@ -628,12 +703,14 @@ export class AgentsDatabase {
     return this.db.prepare('SELECT * FROM skills WHERE id = ?').get(id) as SkillRow | undefined
   }
 
-  listSkills(opts: { seller?: string; category?: string; status?: string; limit?: number; offset?: number }): SkillRow[] {
+  listSkills(opts: { seller?: string; category?: string; status?: string; productType?: string; paymentMethod?: string; limit?: number; offset?: number }): SkillRow[] {
     const conditions: string[] = []
     const values: unknown[] = []
 
     if (opts.seller) { conditions.push('seller = ?'); values.push(opts.seller.toLowerCase()) }
     if (opts.category) { conditions.push('category = ?'); values.push(opts.category) }
+    if (opts.productType) { conditions.push('product_type = ?'); values.push(opts.productType) }
+    if (opts.paymentMethod) { conditions.push('payment_method = ?'); values.push(opts.paymentMethod) }
     conditions.push('status = ?'); values.push(opts.status ?? 'active')
 
     const where = `WHERE ${conditions.join(' AND ')}`
@@ -642,12 +719,14 @@ export class AgentsDatabase {
     ).all(...values, opts.limit ?? 50, opts.offset ?? 0) as SkillRow[]
   }
 
-  countSkills(opts: { seller?: string; category?: string; status?: string }): number {
+  countSkills(opts: { seller?: string; category?: string; status?: string; productType?: string; paymentMethod?: string }): number {
     const conditions: string[] = []
     const values: unknown[] = []
 
     if (opts.seller) { conditions.push('seller = ?'); values.push(opts.seller.toLowerCase()) }
     if (opts.category) { conditions.push('category = ?'); values.push(opts.category) }
+    if (opts.productType) { conditions.push('product_type = ?'); values.push(opts.productType) }
+    if (opts.paymentMethod) { conditions.push('payment_method = ?'); values.push(opts.paymentMethod) }
     conditions.push('status = ?'); values.push(opts.status ?? 'active')
 
     const where = `WHERE ${conditions.join(' AND ')}`
@@ -736,6 +815,88 @@ export class AgentsDatabase {
       result.set(row.skill_id, { available: row.available_count, totalSales: row.total_sales })
     }
     return result
+  }
+
+  // === x402 Payments ===
+
+  recordX402Payment(payment: {
+    id: string
+    skillId: string
+    buyerAddress: string
+    sellerAddress: string
+    amount: string
+    fee: string
+    txHash: string
+    settledAt: number
+  }): boolean {
+    this.db.prepare(
+      `INSERT INTO x402_payments (id, skill_id, buyer_address, seller_address, amount, fee, tx_hash, settled_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      payment.id, payment.skillId, payment.buyerAddress.toLowerCase(),
+      payment.sellerAddress.toLowerCase(), payment.amount, payment.fee,
+      payment.txHash, payment.settledAt,
+    )
+    return true
+  }
+
+  listX402Payments(skillId: string): any[] {
+    return this.db.prepare(
+      'SELECT * FROM x402_payments WHERE skill_id = ? ORDER BY settled_at DESC'
+    ).all(skillId)
+  }
+
+  getX402PaymentByTxHash(txHash: string): any | undefined {
+    return this.db.prepare(
+      'SELECT * FROM x402_payments WHERE tx_hash = ?'
+    ).get(txHash)
+  }
+
+  listX402PaymentsBySeller(sellerAddress: string, limit = 50): any[] {
+    return this.db.prepare(
+      'SELECT * FROM x402_payments WHERE seller_address = ? ORDER BY settled_at DESC LIMIT ?'
+    ).all(sellerAddress.toLowerCase(), limit)
+  }
+
+  getPendingForwardsBySeller(sellerAddress: string): any[] {
+    return this.db.prepare(
+      "SELECT * FROM pending_forwards WHERE seller = ? AND status = 'pending'"
+    ).all(sellerAddress.toLowerCase())
+  }
+
+  recordPendingForward(forward: {
+    paymentId: string
+    skillId: string
+    seller: string
+    amount: string
+  }): void {
+    const now = Math.floor(Date.now() / 1000)
+    this.db.prepare(
+      `INSERT INTO pending_forwards (payment_id, skill_id, seller, amount, status, created_at)
+       VALUES (?, ?, ?, ?, 'pending', ?)`
+    ).run(forward.paymentId, forward.skillId, forward.seller.toLowerCase(), forward.amount, now)
+  }
+
+  updatePendingForward(paymentId: string, status: string, txHash?: string): void {
+    const now = Math.floor(Date.now() / 1000)
+    this.db.prepare(
+      'UPDATE pending_forwards SET status = ?, forward_tx_hash = ?, updated_at = ? WHERE payment_id = ?'
+    ).run(status, txHash ?? null, now, paymentId)
+  }
+
+  getPendingForwards(): Array<{
+    payment_id: string
+    skill_id: string
+    seller: string
+    amount: string
+    status: string
+    forward_tx_hash: string | null
+    created_at: number
+    updated_at: number | null
+  }> {
+    return this.db.prepare(
+      "SELECT * FROM pending_forwards WHERE status = 'pending' ORDER BY created_at ASC"
+    ).all() as any[]
   }
 
   // === Votes ===
@@ -1085,6 +1246,55 @@ export class AgentsDatabase {
       `SELECT * FROM bounties ${where} ${orderBy} LIMIT ? OFFSET ?`
     ).all(...values, limit, offset) as BountyRow[]
   }
+
+  // === Product Types ===
+
+  getProductType(id: string): ProductTypeRow | undefined {
+    return this.db.prepare('SELECT * FROM product_types WHERE id = ?').get(id) as ProductTypeRow | undefined
+  }
+
+  createProductType(type: {
+    id: string
+    name: string
+    description?: string
+    schema: string
+    contentFormat?: string
+    freeDownloadAllowed?: number
+    creator: string
+    createdAt: number
+  }): boolean {
+    try {
+      this.db.prepare(
+        `INSERT INTO product_types (id, name, description, schema, content_format, free_download_allowed, creator, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+      ).run(
+        type.id, type.name, type.description ?? '', type.schema,
+        type.contentFormat ?? 'binary', type.freeDownloadAllowed ?? 1,
+        type.creator, type.createdAt,
+      )
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  listProductTypes(): ProductTypeRow[] {
+    return this.db.prepare('SELECT * FROM product_types ORDER BY created_at ASC').all() as ProductTypeRow[]
+  }
+
+  validateMetadata(metadata: unknown, schemaStr: string): string | null {
+    try {
+      const ajv = new Ajv()
+      const schema = JSON.parse(schemaStr)
+      const validate = ajv.compile(schema)
+      if (!validate(metadata)) {
+        return validate.errors?.map((e: any) => `${e.instancePath} ${e.message}`).join('; ') ?? 'Validation failed'
+      }
+      return null
+    } catch (err) {
+      return `Schema validation error: ${err instanceof Error ? err.message : err}`
+    }
+  }
 }
 
 // Row types
@@ -1219,9 +1429,24 @@ export interface SkillRow {
   content_hash: string
   encrypted_data_ref: string
   escrow_id: number | null
+  product_type: string | null
+  metadata: string | null
+  payment_method: string
+  x402_content_key: string | null
   status: string
   total_sales: number
   avg_rating: number
+  created_at: number
+}
+
+export interface ProductTypeRow {
+  id: string
+  name: string
+  description: string
+  schema: string
+  content_format: string
+  free_download_allowed: number
+  creator: string
   created_at: number
 }
 

--- a/packages/agents-api/src/db/seed-product-types.ts
+++ b/packages/agents-api/src/db/seed-product-types.ts
@@ -1,0 +1,30 @@
+import type { AgentsDatabase } from './database.js'
+
+const ENGRAM_PACK = {
+  id: 'engram-pack',
+  name: 'Engram Pack',
+  description: 'Curated AI knowledge packs (engrams) for agent learning',
+  schema: JSON.stringify({
+    type: 'object',
+    properties: {
+      engram_count: { type: 'integer', minimum: 1 },
+      domain: { type: 'string' },
+      match_terms: { type: 'array', items: { type: 'string' } },
+      fitness_score: { type: 'number', minimum: 0, maximum: 1 },
+      version: { type: 'string' },
+      license: { type: 'string' },
+    },
+    required: ['engram_count', 'domain', 'version'],
+  }),
+  contentFormat: 'tar.gz',
+  freeDownloadAllowed: 1,
+  creator: 'system',
+  createdAt: Math.floor(Date.now() / 1000),
+}
+
+export function seedProductTypes(db: AgentsDatabase): void {
+  if (!db.getProductType('engram-pack')) {
+    db.createProductType(ENGRAM_PACK)
+    console.log('[seed] Registered engram-pack product type')
+  }
+}

--- a/packages/agents-api/src/index.ts
+++ b/packages/agents-api/src/index.ts
@@ -8,6 +8,7 @@ import { loadConfig } from './config.js'
 import { AgentsDatabase } from './db/database.js'
 import { EscrowIndexer } from './indexer/escrow-indexer.js'
 import { createServer } from './api/server.js'
+import { seedProductTypes } from './db/seed-product-types.js'
 
 const config = loadConfig()
 
@@ -53,6 +54,8 @@ if (process.env.PAYMENT_PROXY_ADDRESS) {
     throw new Error('[x402] FATAL: RELAYER_KEY must be a 64-hex-char private key (with optional 0x prefix)')
   }
 }
+
+seedProductTypes(db)
 
 const app = createServer(db, indexer)
 

--- a/packages/agents-api/src/index.ts
+++ b/packages/agents-api/src/index.ts
@@ -25,6 +25,35 @@ const indexer = new EscrowIndexer(
   config.catchupBatchSize,
 )
 
+// === x402 configuration validation ===
+if (process.env.PAYMENT_PROXY_ADDRESS) {
+  console.log('[x402] PaymentProxy:', process.env.PAYMENT_PROXY_ADDRESS)
+
+  if (!process.env.X402_CONTENT_KEY_SECRET) {
+    throw new Error('[x402] FATAL: X402_CONTENT_KEY_SECRET is required when PAYMENT_PROXY_ADDRESS is set. Generate with: openssl rand -hex 32')
+  }
+  if (!/^[0-9a-f]{64}$/i.test(process.env.X402_CONTENT_KEY_SECRET)) {
+    throw new Error('[x402] FATAL: X402_CONTENT_KEY_SECRET must be exactly 64 hex characters (32 bytes). Generate with: openssl rand -hex 32')
+  }
+
+  const facilitatorUrl = process.env.X402_FACILITATOR_URL || 'https://x402.org/facilitator'
+  try {
+    const parsed = new URL(facilitatorUrl)
+    if (parsed.protocol !== 'https:' && parsed.hostname !== 'localhost' && parsed.hostname !== '127.0.0.1') {
+      throw new Error(`[x402] FATAL: Facilitator URL must use HTTPS for non-local hosts: ${facilitatorUrl}`)
+    }
+  } catch (err) {
+    if (err instanceof Error && err.message.includes('FATAL')) throw err
+    throw new Error(`[x402] FATAL: Invalid X402_FACILITATOR_URL: ${facilitatorUrl}`)
+  }
+
+  if (!process.env.RELAYER_KEY) {
+    console.warn('[x402] WARNING: RELAYER_KEY not set — proxy.forward() will not work')
+  } else if (!/^(0x)?[0-9a-f]{64}$/i.test(process.env.RELAYER_KEY)) {
+    throw new Error('[x402] FATAL: RELAYER_KEY must be a 64-hex-char private key (with optional 0x prefix)')
+  }
+}
+
 const app = createServer(db, indexer)
 
 // Start indexer

--- a/packages/agents-api/test/api.test.ts
+++ b/packages/agents-api/test/api.test.ts
@@ -5,6 +5,12 @@ import { createServer } from '../src/api/server.js'
 import { mkdtempSync, rmSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
+import { randomUUID } from 'crypto'
+import { privateKeyToAccount } from 'viem/accounts'
+
+// Test wallet (hardhat account #0 — deterministic, never holds real funds)
+const TEST_PRIVATE_KEY = '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80' as const
+const testAccount = privateKeyToAccount(TEST_PRIVATE_KEY)
 
 describe('API routes', () => {
   let db: AgentsDatabase
@@ -47,15 +53,29 @@ describe('API routes', () => {
   })
 
   // Use supertest-like approach with raw http
-  async function request(path: string): Promise<{ status: number; body: any }> {
+  async function request(
+    path: string,
+    opts?: { method?: string; headers?: Record<string, string>; body?: string },
+  ): Promise<{ status: number; body: any }> {
     return new Promise((resolve) => {
       const { createServer: httpServer } = require('http')
       const s = httpServer(server)
       s.listen(0, () => {
         const port = s.address().port
-        fetch(`http://localhost:${port}${path}`)
+        const fetchOpts: RequestInit = {}
+        if (opts?.method) fetchOpts.method = opts.method
+        if (opts?.headers) fetchOpts.headers = opts.headers
+        if (opts?.body) fetchOpts.body = opts.body
+
+        fetch(`http://localhost:${port}${path}`, fetchOpts)
           .then(async (res) => {
-            const body = await res.json()
+            let body: any
+            const contentType = res.headers.get('content-type') || ''
+            if (contentType.includes('json')) {
+              body = await res.json()
+            } else {
+              body = { _text: await res.text(), _location: res.headers.get('location') }
+            }
             s.close()
             resolve({ status: res.status, body })
           })
@@ -64,6 +84,30 @@ describe('API routes', () => {
             resolve({ status: 500, body: { error: err.message } })
           })
       })
+    })
+  }
+
+  /** POST with EIP-191 signature headers */
+  async function signedRequest(
+    path: string,
+    body: Record<string, unknown>,
+  ): Promise<{ status: number; body: any }> {
+    const timestamp = Math.floor(Date.now() / 1000).toString()
+    const nonce = randomUUID()
+    const bodyStr = JSON.stringify(body)
+    const message = `${timestamp}:${nonce}:${bodyStr}`
+    const signature = await testAccount.signMessage({ message })
+
+    return request(path, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Address': testAccount.address,
+        'X-Signature': signature,
+        'X-Timestamp': timestamp,
+        'X-Nonce': nonce,
+      },
+      body: bodyStr,
     })
   }
 
@@ -102,5 +146,294 @@ describe('API routes', () => {
     const res = await request('/api/v1/stats')
     expect(res.status).toBe(200)
     expect(res.body.total_escrows).toBeDefined()
+  })
+
+  // === Product Type tests ===
+
+  describe('Product Types', () => {
+    const testSchema = {
+      type: 'object',
+      properties: {
+        version: { type: 'string' },
+        engram_count: { type: 'number' },
+      },
+      required: ['version'],
+    }
+
+    it('POST /product-types without signature returns 401', async () => {
+      const res = await request('/api/v1/product-types', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: 'test-type', name: 'Test', schema: testSchema }),
+      })
+      expect(res.status).toBe(401)
+    })
+
+    it('POST /product-types with valid signature returns 201', async () => {
+      const res = await signedRequest('/api/v1/product-types', {
+        id: 'engram-pack',
+        name: 'Engram Pack',
+        description: 'Datacore engram pack',
+        schema: testSchema,
+        content_format: 'json',
+        free_download_allowed: 1,
+      })
+      expect(res.status).toBe(201)
+      expect(res.body.id).toBe('engram-pack')
+      expect(res.body.name).toBe('Engram Pack')
+    })
+
+    it('POST /product-types with duplicate id returns 409', async () => {
+      const res = await signedRequest('/api/v1/product-types', {
+        id: 'engram-pack',
+        name: 'Duplicate',
+        schema: testSchema,
+      })
+      expect(res.status).toBe(409)
+    })
+
+    it('GET /product-types lists types', async () => {
+      const res = await request('/api/v1/product-types')
+      expect(res.status).toBe(200)
+      expect(res.body.product_types).toBeInstanceOf(Array)
+      expect(res.body.product_types.length).toBeGreaterThanOrEqual(1)
+      const ep = res.body.product_types.find((t: any) => t.id === 'engram-pack')
+      expect(ep).toBeDefined()
+      expect(ep.schema.type).toBe('object')
+    })
+
+    it('GET /product-types/:id returns type with parsed schema', async () => {
+      const res = await request('/api/v1/product-types/engram-pack')
+      expect(res.status).toBe(200)
+      expect(res.body.id).toBe('engram-pack')
+      expect(res.body.schema.type).toBe('object')
+      expect(res.body.schema.required).toContain('version')
+    })
+
+    it('GET /product-types/:id returns 404 for unknown type', async () => {
+      const res = await request('/api/v1/product-types/nonexistent')
+      expect(res.status).toBe(404)
+    })
+  })
+
+  // === Skills with product types tests ===
+
+  describe('Skills with product types', () => {
+    it('POST /skills without signature returns 401', async () => {
+      const res = await request('/api/v1/skills', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          seller: testAccount.address,
+          title: 'Unsigned Skill',
+        }),
+      })
+      expect(res.status).toBe(401)
+    })
+
+    it('POST /skills with valid product_type + valid metadata returns 201', async () => {
+      const res = await signedRequest('/api/v1/skills', {
+        seller: testAccount.address,
+        title: 'My Engram Pack',
+        description: 'A test engram pack',
+        category: 'dataset',
+        price: '0',
+        product_type: 'engram-pack',
+        metadata: { version: '1.0.0', engram_count: 42 },
+      })
+      expect(res.status).toBe(201)
+      expect(res.body.product_type).toBe('engram-pack')
+      expect(res.body.id).toBeDefined()
+    })
+
+    it('POST /skills with valid product_type + invalid metadata returns 400', async () => {
+      const res = await signedRequest('/api/v1/skills', {
+        seller: testAccount.address,
+        title: 'Bad Metadata Pack',
+        description: 'Missing required version',
+        category: 'dataset',
+        price: '0',
+        product_type: 'engram-pack',
+        metadata: { engram_count: 10 },
+      })
+      expect(res.status).toBe(400)
+      expect(res.body.error).toContain('Invalid metadata')
+    })
+
+    it('POST /skills without product_type returns 201 (backward compat)', async () => {
+      const res = await signedRequest('/api/v1/skills', {
+        seller: testAccount.address,
+        title: 'Legacy Skill',
+        description: 'No product type',
+        category: 'research',
+        price: '1000000000000000',
+      })
+      expect(res.status).toBe(201)
+      expect(res.body.product_type).toBeNull()
+    })
+
+    it('POST /skills with unknown product_type returns 400', async () => {
+      const res = await signedRequest('/api/v1/skills', {
+        seller: testAccount.address,
+        title: 'Unknown Type Skill',
+        product_type: 'nonexistent-type',
+        metadata: {},
+      })
+      expect(res.status).toBe(400)
+      expect(res.body.error).toContain('Unknown product_type')
+    })
+
+    it('GET /skills?product_type=engram-pack filters correctly', async () => {
+      const res = await request('/api/v1/skills?product_type=engram-pack')
+      expect(res.status).toBe(200)
+      expect(res.body.skills).toBeInstanceOf(Array)
+      for (const skill of res.body.skills) {
+        expect(skill.product_type).toBe('engram-pack')
+      }
+      // Should have at least the one we created
+      expect(res.body.skills.length).toBeGreaterThanOrEqual(1)
+    })
+
+    it('GET /skills/:id/download for free skill redirects', async () => {
+      // Create a free skill with a data ref
+      const createRes = await signedRequest('/api/v1/skills', {
+        seller: testAccount.address,
+        title: 'Free Pack',
+        description: 'A free pack for download',
+        category: 'dataset',
+        price: '0',
+        encryptedDataRef: 'abc123swarmref',
+        product_type: 'engram-pack',
+        metadata: { version: '0.1.0' },
+      })
+      expect(createRes.status).toBe(201)
+      const skillId = createRes.body.id
+
+      // Attempt to download — should redirect to Swarm gateway
+      const dlRes = await request(`/api/v1/skills/${skillId}/download`)
+      // fetch follows redirects by default, so we may get a network error
+      // or a redirect status. The key is it's not 403/404.
+      // Since we use a fake swarm ref, the redirect URL won't resolve,
+      // but we verify the route logic works by checking it's not a 403.
+      expect([200, 302, 500]).toContain(dlRes.status)
+    })
+
+    it('GET /skills/:id/download for paid skill returns 403', async () => {
+      // Create a paid skill
+      const createRes = await signedRequest('/api/v1/skills', {
+        seller: testAccount.address,
+        title: 'Paid Pack',
+        description: 'Costs money',
+        category: 'dataset',
+        price: '1000000000000000',
+        encryptedDataRef: 'def456swarmref',
+      })
+      expect(createRes.status).toBe(201)
+      const skillId = createRes.body.id
+
+      const dlRes = await request(`/api/v1/skills/${skillId}/download`)
+      expect(dlRes.status).toBe(403)
+    })
+  })
+
+  // === x402 schema tests ===
+
+  describe('x402 schema', () => {
+    // IMPORTANT: X402_CONTENT_KEY_SECRET must be set for tests that call createSkill with x402ContentKey.
+    beforeAll(() => {
+      process.env.X402_CONTENT_KEY_SECRET = 'a'.repeat(64)
+    })
+    afterAll(() => {
+      delete process.env.X402_CONTENT_KEY_SECRET
+    })
+    let testSkillId: string
+    it('creates a skill with payment_method=x402', async () => {
+      const { status, body } = await signedRequest('/api/v1/skills', {
+        seller: testAccount.address,
+        title: 'Test x402 Skill',
+        price: '500000',
+        payment_method: 'x402',
+      })
+      expect(status).toBe(201)
+      expect(body.payment_method).toBe('x402')
+      testSkillId = body.id
+    })
+
+    it('defaults payment_method to escrow', async () => {
+      const { status, body } = await signedRequest('/api/v1/skills', {
+        seller: testAccount.address,
+        title: 'Default Method',
+        price: '100000',
+      })
+      expect(status).toBe(201)
+      expect(body.payment_method).toBe('escrow')
+    })
+
+    it('filters by payment_method', async () => {
+      const { body } = await request('/api/v1/skills?payment_method=x402')
+      expect(body.skills.every((s: any) => s.payment_method === 'x402')).toBe(true)
+    })
+
+    it('records x402 payment with unique tx_hash', () => {
+      const txHash = '0x' + 'a'.repeat(64)
+      db.recordX402Payment({
+        id: 'pay-001',
+        skillId: testSkillId,
+        buyerAddress: '0x' + '1'.repeat(40),
+        sellerAddress: '0x' + '2'.repeat(40),
+        amount: '500000',
+        fee: '0',
+        txHash,
+        settledAt: Math.floor(Date.now() / 1000),
+      })
+      const payments = db.listX402Payments(testSkillId)
+      expect(payments.length).toBe(1)
+      expect(payments[0].tx_hash).toBe(txHash)
+    })
+
+    it('rejects duplicate tx_hash', () => {
+      const txHash = '0x' + 'b'.repeat(64)
+      db.recordX402Payment({
+        id: 'pay-dup-1',
+        skillId: testSkillId,
+        buyerAddress: '0x' + '1'.repeat(40),
+        sellerAddress: '0x' + '2'.repeat(40),
+        amount: '500000',
+        fee: '0',
+        txHash,
+        settledAt: Math.floor(Date.now() / 1000),
+      })
+      expect(() => db.recordX402Payment({
+        id: 'pay-dup-2',
+        skillId: testSkillId,
+        buyerAddress: '0x' + '1'.repeat(40),
+        sellerAddress: '0x' + '2'.repeat(40),
+        amount: '500000',
+        fee: '0',
+        txHash,
+        settledAt: Math.floor(Date.now() / 1000),
+      })).toThrow()
+    })
+
+    it('never exposes x402_content_key in API responses', async () => {
+      const { body: single } = await request(`/api/v1/skills/${testSkillId}`)
+      expect(single.x402_content_key).toBeUndefined()
+      expect(single.encrypted_data_ref).toBeUndefined()
+    })
+
+    it('server encrypts content key from client', () => {
+      const rawKey = 'c'.repeat(64)
+      db.createSkill({
+        id: 'skill-key-encrypt-test',
+        seller: 'test',
+        title: 'Key Test',
+        price: '500000',
+        paymentMethod: 'x402',
+        x402ContentKey: rawKey,
+        createdAt: Math.floor(Date.now() / 1000),
+      })
+      const row = db.getSkill('skill-key-encrypt-test')
+      expect(row).toBeTruthy()
+    })
   })
 })

--- a/packages/agents-api/test/api.test.ts
+++ b/packages/agents-api/test/api.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import { AgentsDatabase } from '../src/db/database.js'
+import { seedProductTypes } from '../src/db/seed-product-types.js'
 import { EscrowIndexer } from '../src/indexer/escrow-indexer.js'
 import { createServer } from '../src/api/server.js'
 import { mkdtempSync, rmSync } from 'fs'
@@ -20,6 +21,7 @@ describe('API routes', () => {
   beforeAll(() => {
     tmpDir = mkdtempSync(join(tmpdir(), 'agents-api-test-'))
     db = new AgentsDatabase(join(tmpDir, 'test.db'))
+    seedProductTypes(db)
 
     // Create a mock indexer
     const indexer = {
@@ -171,21 +173,21 @@ describe('API routes', () => {
 
     it('POST /product-types with valid signature returns 201', async () => {
       const res = await signedRequest('/api/v1/product-types', {
-        id: 'engram-pack',
-        name: 'Engram Pack',
+        id: 'test-type',
+        name: 'Test Type',
         description: 'Datacore engram pack',
         schema: testSchema,
         content_format: 'json',
         free_download_allowed: 1,
       })
       expect(res.status).toBe(201)
-      expect(res.body.id).toBe('engram-pack')
-      expect(res.body.name).toBe('Engram Pack')
+      expect(res.body.id).toBe('test-type')
+      expect(res.body.name).toBe('Test Type')
     })
 
     it('POST /product-types with duplicate id returns 409', async () => {
       const res = await signedRequest('/api/v1/product-types', {
-        id: 'engram-pack',
+        id: 'test-type',
         name: 'Duplicate',
         schema: testSchema,
       })
@@ -203,9 +205,9 @@ describe('API routes', () => {
     })
 
     it('GET /product-types/:id returns type with parsed schema', async () => {
-      const res = await request('/api/v1/product-types/engram-pack')
+      const res = await request('/api/v1/product-types/test-type')
       expect(res.status).toBe(200)
-      expect(res.body.id).toBe('engram-pack')
+      expect(res.body.id).toBe('test-type')
       expect(res.body.schema.type).toBe('object')
       expect(res.body.schema.required).toContain('version')
     })
@@ -213,6 +215,30 @@ describe('API routes', () => {
     it('GET /product-types/:id returns 404 for unknown type', async () => {
       const res = await request('/api/v1/product-types/nonexistent')
       expect(res.status).toBe(404)
+    })
+  })
+
+  // === Seeded engram-pack tests ===
+
+  describe('engram-pack product type (seeded)', () => {
+    it('GET /product-types/engram-pack returns seeded type', async () => {
+      const { status, body } = await request('/api/v1/product-types/engram-pack')
+      expect(status).toBe(200)
+      expect(body.id).toBe('engram-pack')
+      expect(body.schema.required).toContain('engram_count')
+      expect(body.content_format).toBe('tar.gz')
+    })
+
+    it('validates metadata on skill creation', async () => {
+      const { status } = await signedRequest('/api/v1/skills', {
+        seller: testAccount.address,
+        title: 'Valid Pack',
+        price: '500000',
+        payment_method: 'x402',
+        product_type: 'engram-pack',
+        metadata: { engram_count: 50, domain: 'software.testing', version: '1.0.0' },
+      })
+      expect(status).toBe(201)
     })
   })
 
@@ -239,7 +265,7 @@ describe('API routes', () => {
         category: 'dataset',
         price: '0',
         product_type: 'engram-pack',
-        metadata: { version: '1.0.0', engram_count: 42 },
+        metadata: { version: '1.0.0', engram_count: 42, domain: 'test' },
       })
       expect(res.status).toBe(201)
       expect(res.body.product_type).toBe('engram-pack')
@@ -304,7 +330,7 @@ describe('API routes', () => {
         price: '0',
         encryptedDataRef: 'a'.repeat(64),
         product_type: 'engram-pack',
-        metadata: { version: '0.1.0' },
+        metadata: { version: '0.1.0', engram_count: 5, domain: 'test' },
       })
       expect(createRes.status).toBe(201)
       const skillId = createRes.body.id

--- a/packages/agents-api/test/api.test.ts
+++ b/packages/agents-api/test/api.test.ts
@@ -403,16 +403,17 @@ describe('API routes', () => {
         txHash,
         settledAt: Math.floor(Date.now() / 1000),
       })
-      expect(() => db.recordX402Payment({
+      const result = db.recordX402Payment({
         id: 'pay-dup-2',
         skillId: testSkillId,
         buyerAddress: '0x' + '1'.repeat(40),
         sellerAddress: '0x' + '2'.repeat(40),
         amount: '500000',
         fee: '0',
-        txHash,
+        txHash, // same hash — must fail
         settledAt: Math.floor(Date.now() / 1000),
-      })).toThrow()
+      })
+      expect(result).toBe(false)
     })
 
     it('never exposes x402_content_key in API responses', async () => {
@@ -434,6 +435,8 @@ describe('API routes', () => {
       })
       const row = db.getSkill('skill-key-encrypt-test')
       expect(row).toBeTruthy()
+      expect(row!.x402_content_key).not.toBe(rawKey)
+      expect(row!.x402_content_key).not.toBeNull()
     })
   })
 })

--- a/packages/agents-api/test/api.test.ts
+++ b/packages/agents-api/test/api.test.ts
@@ -295,14 +295,14 @@ describe('API routes', () => {
     })
 
     it('GET /skills/:id/download for free skill redirects', async () => {
-      // Create a free skill with a data ref
+      // Create a free skill with a valid 64-hex Swarm reference
       const createRes = await signedRequest('/api/v1/skills', {
         seller: testAccount.address,
         title: 'Free Pack',
         description: 'A free pack for download',
         category: 'dataset',
         price: '0',
-        encryptedDataRef: 'abc123swarmref',
+        encryptedDataRef: 'a'.repeat(64),
         product_type: 'engram-pack',
         metadata: { version: '0.1.0' },
       })

--- a/packages/agents-api/test/x402.test.ts
+++ b/packages/agents-api/test/x402.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import { AgentsDatabase } from '../src/db/database.js'
+
+describe('x402 download paywall', () => {
+  let db: AgentsDatabase
+  let server: any
+  let port: number
+  let tmpDir: string
+
+  const FREE_ID = 'skill-free-001'
+  const X402_ID = 'skill-x402-001'
+  const ESCROW_ID = 'skill-escrow-001'
+
+  beforeAll(async () => {
+    process.env.PAYMENT_PROXY_ADDRESS = '0x' + '1'.repeat(40)
+    process.env.X402_CONTENT_KEY_SECRET = 'a'.repeat(64)
+    process.env.X402_FACILITATOR_URL = 'http://mock-facilitator'
+
+    tmpDir = mkdtempSync(join(tmpdir(), 'x402-test-'))
+    db = new AgentsDatabase(join(tmpDir, 'test.db'))
+
+    db.createSkill({
+      id: FREE_ID,
+      seller: '0xseller',
+      title: 'Free Pack',
+      price: '0',
+      paymentMethod: 'free',
+      encryptedDataRef: 'a'.repeat(64),
+      createdAt: Math.floor(Date.now() / 1000),
+    })
+
+    db.createSkill({
+      id: X402_ID,
+      seller: '0xseller',
+      title: 'Paid Pack',
+      price: '500000',
+      paymentMethod: 'x402',
+      encryptedDataRef: 'b'.repeat(64),
+      x402ContentKey: 'c'.repeat(64),
+      createdAt: Math.floor(Date.now() / 1000),
+    })
+
+    db.createSkill({
+      id: ESCROW_ID,
+      seller: '0xseller',
+      title: 'Escrow Pack',
+      price: '10000000',
+      paymentMethod: 'escrow',
+      createdAt: Math.floor(Date.now() / 1000),
+    })
+
+    const { createServer } = await import('../src/api/server.js')
+    const mockIndexer = {
+      start: vi.fn(),
+      stop: vi.fn(),
+      getStatus: vi.fn().mockReturnValue({ chains: [], lastBlock: 0, isRunning: false }),
+    } as any
+    const app = createServer(db, mockIndexer)
+    server = app.listen(0)
+    port = (server.address() as any).port
+  })
+
+  afterAll(() => {
+    server?.close()
+    rmSync(tmpDir, { recursive: true })
+    delete process.env.PAYMENT_PROXY_ADDRESS
+    delete process.env.X402_CONTENT_KEY_SECRET
+    delete process.env.X402_FACILITATOR_URL
+  })
+
+  it('returns 302 for free skill', async () => {
+    const res = await fetch(
+      `http://localhost:${port}/api/v1/skills/${FREE_ID}/download`,
+      { redirect: 'manual' },
+    )
+    expect([200, 302]).toContain(res.status)
+  })
+
+  it('returns 403 for escrow skill', async () => {
+    const res = await fetch(`http://localhost:${port}/api/v1/skills/${ESCROW_ID}/download`)
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 402 for x402 skill without payment header', async () => {
+    const res = await fetch(`http://localhost:${port}/api/v1/skills/${X402_ID}/download`)
+    expect(res.status).toBe(402)
+    const body = await res.json() as any
+    expect(body.x402Version).toBe(2)
+    expect(body.paymentRequirements).toHaveLength(1)
+    const req = body.paymentRequirements[0]
+    expect(req.scheme).toBe('exact')
+    expect(req.network).toBe('eip155:8453')
+    expect(req.maxAmountRequired).toBe('500000')
+    expect(req.extra.seller).toBe('0xseller')
+    expect(req.extra.skillId).toBe(X402_ID)
+  })
+
+  it('does not expose content key in 402 response', async () => {
+    const res = await fetch(`http://localhost:${port}/api/v1/skills/${X402_ID}/download`)
+    const text = await res.text()
+    expect(text).not.toContain('x402_content_key')
+  })
+
+  it('returns 404 for nonexistent skill', async () => {
+    const res = await fetch(`http://localhost:${port}/api/v1/skills/nonexistent/download`)
+    expect(res.status).toBe(404)
+  })
+
+  it('rejects duplicate tx_hash via recordX402Payment', () => {
+    const txHash = '0x' + 'f'.repeat(64)
+    db.recordX402Payment({
+      id: 'pre-existing',
+      skillId: X402_ID,
+      buyerAddress: '0xbuyer',
+      sellerAddress: '0xseller',
+      amount: '500000',
+      fee: '0',
+      txHash,
+      settledAt: Math.floor(Date.now() / 1000),
+    })
+    // recordX402Payment returns false on duplicate (not throw)
+    const result = db.recordX402Payment({
+      id: 'duplicate',
+      skillId: X402_ID,
+      buyerAddress: '0xbuyer',
+      sellerAddress: '0xseller',
+      amount: '500000',
+      fee: '0',
+      txHash,
+      settledAt: Math.floor(Date.now() / 1000),
+    })
+    expect(result).toBe(false)
+  })
+
+  it('re-download rejects mismatched buyer address', async () => {
+    const txHash = '0x' + 'd'.repeat(64)
+    db.recordX402Payment({
+      id: 'buyer-auth-test',
+      skillId: X402_ID,
+      buyerAddress: '0xrealbuyer',
+      sellerAddress: '0xseller',
+      amount: '500000',
+      fee: '0',
+      txHash,
+      settledAt: Math.floor(Date.now() / 1000),
+    })
+    const res = await fetch(
+      `http://localhost:${port}/api/v1/skills/${X402_ID}/download?tx_hash=${txHash}`,
+      { headers: { 'X-Buyer-Address': '0xwrongbuyer' } }
+    )
+    expect(res.status).toBe(403)
+  })
+
+  it('re-download without X-Buyer-Address returns 401', async () => {
+    const txHash = '0x' + 'e'.repeat(64)
+    db.recordX402Payment({
+      id: 'redownload-no-header',
+      skillId: X402_ID,
+      buyerAddress: '0xbuyer',
+      sellerAddress: '0xseller',
+      amount: '500000',
+      fee: '0',
+      txHash,
+      settledAt: Math.floor(Date.now() / 1000),
+    })
+    const res = await fetch(
+      `http://localhost:${port}/api/v1/skills/${X402_ID}/download?tx_hash=${txHash}`
+    )
+    expect(res.status).toBe(401)
+    const body = await res.json() as any
+    expect(body.error).toContain('X-Buyer-Address')
+  })
+
+  it('re-download with valid tx_hash and buyer address reaches Swarm', async () => {
+    const txHash = '0x' + 'e'.repeat(64)
+    const res = await fetch(
+      `http://localhost:${port}/api/v1/skills/${X402_ID}/download?tx_hash=${txHash}`,
+      { headers: { 'X-Buyer-Address': '0xbuyer' } }
+    )
+    // Passes auth check; Swarm unreachable in test -> 502
+    expect(res.status).toBe(502)
+  })
+})

--- a/packages/contracts/package-lock.json
+++ b/packages/contracts/package-lock.json
@@ -1,0 +1,411 @@
+{
+  "name": "@fairdrop/contracts",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@fairdrop/contracts",
+      "version": "0.1.0",
+      "dependencies": {
+        "ethers": "^6.13.0",
+        "viem": "^2.46.3"
+      },
+      "devDependencies": {
+        "typescript": "^5.5.0"
+      }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
+      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
+      "license": "MIT"
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/abitype": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
+      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "license": "MIT"
+    },
+    "node_modules/ethers": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.16.0.tgz",
+      "integrity": "sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "22.7.5",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.7.0",
+        "ws": "8.17.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/ox": {
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.12.4.tgz",
+      "integrity": "sha512-+P+C7QzuwPV8lu79dOwjBKfB2CbnbEXe/hfyyrff1drrO1nOOj3Hc87svHfcW1yneRr3WXaKr6nz11nq+/DF9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ox/node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "license": "MIT"
+    },
+    "node_modules/ox/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ox/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "license": "MIT"
+    },
+    "node_modules/viem": {
+      "version": "2.46.3",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.46.3.tgz",
+      "integrity": "sha512-2LJS+Hyh2sYjHXQtzfv1kU9pZx9dxFzvoU/ZKIcn0FNtOU0HQuIICuYdWtUDFHaGXbAdVo8J1eCvmjkL9JVGwg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.2.3",
+        "isows": "1.0.7",
+        "ox": "0.12.4",
+        "ws": "8.18.3"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/viem/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/viem/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/viem/node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -9,7 +9,8 @@
     "test": "vitest"
   },
   "dependencies": {
-    "ethers": "^6.13.0"
+    "ethers": "^6.13.0",
+    "viem": "^2.46.3"
   },
   "devDependencies": {
     "typescript": "^5.5.0"

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fairdrop/contracts",
+  "name": "@ade/contracts",
   "version": "0.1.0",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/contracts/sol/.github/workflows/test.yml
+++ b/packages/contracts/sol/.github/workflows/test.yml
@@ -1,0 +1,38 @@
+name: CI
+
+permissions: {}
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  FOUNDRY_PROFILE: ci
+
+jobs:
+  check:
+    name: Foundry project
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+
+      - name: Show Forge version
+        run: forge --version
+
+      - name: Run Forge fmt
+        run: forge fmt --check
+
+      - name: Run Forge build
+        run: forge build --sizes
+
+      - name: Run Forge tests
+        run: forge test -vvv

--- a/packages/contracts/sol/.gitignore
+++ b/packages/contracts/sol/.gitignore
@@ -1,0 +1,14 @@
+# Compiler files
+cache/
+out/
+
+# Ignores development broadcast logs
+!/broadcast
+/broadcast/*/31337/
+/broadcast/**/dry-run/
+
+# Docs
+docs/
+
+# Dotenv file
+.env

--- a/packages/contracts/sol/README.md
+++ b/packages/contracts/sol/README.md
@@ -1,0 +1,66 @@
+## Foundry
+
+**Foundry is a blazing fast, portable and modular toolkit for Ethereum application development written in Rust.**
+
+Foundry consists of:
+
+- **Forge**: Ethereum testing framework (like Truffle, Hardhat and DappTools).
+- **Cast**: Swiss army knife for interacting with EVM smart contracts, sending transactions and getting chain data.
+- **Anvil**: Local Ethereum node, akin to Ganache, Hardhat Network.
+- **Chisel**: Fast, utilitarian, and verbose solidity REPL.
+
+## Documentation
+
+https://book.getfoundry.sh/
+
+## Usage
+
+### Build
+
+```shell
+$ forge build
+```
+
+### Test
+
+```shell
+$ forge test
+```
+
+### Format
+
+```shell
+$ forge fmt
+```
+
+### Gas Snapshots
+
+```shell
+$ forge snapshot
+```
+
+### Anvil
+
+```shell
+$ anvil
+```
+
+### Deploy
+
+```shell
+$ forge script script/Counter.s.sol:CounterScript --rpc-url <your_rpc_url> --private-key <your_private_key>
+```
+
+### Cast
+
+```shell
+$ cast <subcommand>
+```
+
+### Help
+
+```shell
+$ forge --help
+$ anvil --help
+$ cast --help
+```

--- a/packages/contracts/sol/foundry.lock
+++ b/packages/contracts/sol/foundry.lock
@@ -1,0 +1,14 @@
+{
+  "lib/forge-std": {
+    "tag": {
+      "name": "v1.15.0",
+      "rev": "0844d7e1fc5e60d77b68e469bff60265f236c398"
+    }
+  },
+  "lib/openzeppelin-contracts": {
+    "tag": {
+      "name": "v5.1.0",
+      "rev": "69c8def5f222ff96f2b5beff05dfba996368aa79"
+    }
+  }
+}

--- a/packages/contracts/sol/foundry.toml
+++ b/packages/contracts/sol/foundry.toml
@@ -1,0 +1,9 @@
+# packages/contracts/sol/foundry.toml
+[profile.default]
+src = "src"
+out = "out"
+libs = ["lib"]
+solc_version = "0.8.20"
+
+[profile.default.fmt]
+line_length = 120

--- a/packages/contracts/sol/remappings.txt
+++ b/packages/contracts/sol/remappings.txt
@@ -1,0 +1,1 @@
+@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/

--- a/packages/contracts/sol/src/PaymentProxy.sol
+++ b/packages/contracts/sol/src/PaymentProxy.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+contract PaymentProxy is Ownable, ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
+    address public platform;
+    uint16 public feeBps;
+
+    mapping(address => bool) public relayers;
+
+    event PaymentForwarded(
+        address indexed seller,
+        address indexed token,
+        uint256 amount,
+        uint256 fee,
+        bytes32 skillId
+    );
+    event RelayerUpdated(address indexed relayer, bool allowed);
+
+    error OnlyRelayer();
+    error FeeTooHigh();
+    error InsufficientBalance();
+    error ZeroAmount();
+
+    modifier onlyRelayer() {
+        if (!relayers[msg.sender] && msg.sender != owner()) revert OnlyRelayer();
+        _;
+    }
+
+    constructor(address _platform, uint16 _feeBps) Ownable(msg.sender) {
+        if (_feeBps > 2000) revert FeeTooHigh();
+        platform = _platform;
+        feeBps = _feeBps;
+    }
+
+    function forward(
+        address seller,
+        address token,
+        uint256 amount,
+        bytes32 skillId
+    ) external onlyRelayer nonReentrant {
+        if (amount == 0) revert ZeroAmount();
+        uint256 balance = IERC20(token).balanceOf(address(this));
+        if (balance < amount) revert InsufficientBalance();
+
+        uint256 fee = (amount * feeBps) / 10000;
+        uint256 sellerAmount = amount - fee;
+
+        if (fee > 0) {
+            IERC20(token).safeTransfer(platform, fee);
+        }
+        IERC20(token).safeTransfer(seller, sellerAmount);
+
+        emit PaymentForwarded(seller, token, amount, fee, skillId);
+    }
+
+    function setRelayer(address relayer, bool allowed) external onlyOwner {
+        relayers[relayer] = allowed;
+        emit RelayerUpdated(relayer, allowed);
+    }
+
+    function setFeeBps(uint16 _feeBps) external onlyOwner {
+        if (_feeBps > 2000) revert FeeTooHigh();
+        feeBps = _feeBps;
+    }
+
+    function setPlatform(address _platform) external onlyOwner {
+        platform = _platform;
+    }
+
+    /// @notice Recover stuck tokens. Restricted to owner.
+    function recover(address token, address to, uint256 amount) external onlyOwner {
+        IERC20(token).safeTransfer(to, amount);
+    }
+}

--- a/packages/contracts/sol/test/PaymentProxy.t.sol
+++ b/packages/contracts/sol/test/PaymentProxy.t.sol
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../src/PaymentProxy.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockUSDC is ERC20 {
+    constructor() ERC20("USDC", "USDC") {
+        _mint(msg.sender, 1_000_000e6);
+    }
+    function decimals() public pure override returns (uint8) { return 6; }
+}
+
+contract PaymentProxyTest is Test {
+    PaymentProxy proxy;
+    MockUSDC usdc;
+    address owner = address(this);
+    address platform;
+    address relayer;
+    address seller;
+    address attacker;
+
+    event PaymentForwarded(
+        address indexed seller,
+        address indexed token,
+        uint256 amount,
+        uint256 fee,
+        bytes32 skillId
+    );
+
+    function setUp() public {
+        platform = makeAddr("platform");
+        relayer = makeAddr("relayer");
+        seller = makeAddr("seller");
+        attacker = makeAddr("attacker");
+
+        usdc = new MockUSDC();
+        proxy = new PaymentProxy(platform, 0);
+        proxy.setRelayer(relayer, true);
+    }
+
+    function testForwardZeroFee() public {
+        usdc.transfer(address(proxy), 500_000);
+        vm.prank(relayer);
+        proxy.forward(seller, address(usdc), 500_000, bytes32(uint256(1)));
+        assertEq(usdc.balanceOf(seller), 500_000);
+        assertEq(usdc.balanceOf(platform), 0);
+    }
+
+    function testForwardWithFee() public {
+        proxy.setFeeBps(500);
+        usdc.transfer(address(proxy), 1_000_000);
+        vm.prank(relayer);
+        proxy.forward(seller, address(usdc), 1_000_000, bytes32(uint256(2)));
+        assertEq(usdc.balanceOf(seller), 950_000);
+        assertEq(usdc.balanceOf(platform), 50_000);
+    }
+
+    function testOnlyRelayerCanForward() public {
+        usdc.transfer(address(proxy), 100_000);
+        vm.prank(attacker);
+        vm.expectRevert(PaymentProxy.OnlyRelayer.selector);
+        proxy.forward(seller, address(usdc), 100_000, bytes32(0));
+    }
+
+    function testOwnerCanForward() public {
+        usdc.transfer(address(proxy), 100_000);
+        proxy.forward(seller, address(usdc), 100_000, bytes32(0));
+        assertEq(usdc.balanceOf(seller), 100_000);
+    }
+
+    function testFeeCannotExceed20Percent() public {
+        vm.expectRevert(PaymentProxy.FeeTooHigh.selector);
+        proxy.setFeeBps(2001);
+    }
+
+    function testFeeBoundary2000() public {
+        proxy.setFeeBps(2000);
+        assertEq(proxy.feeBps(), 2000);
+    }
+
+    function testRecoverRequiresOwner() public {
+        usdc.transfer(address(proxy), 100_000);
+        vm.prank(attacker);
+        vm.expectRevert();
+        proxy.recover(address(usdc), attacker, 100_000);
+    }
+
+    function testSetPlatformRequiresOwner() public {
+        vm.prank(attacker);
+        vm.expectRevert();
+        proxy.setPlatform(attacker);
+    }
+
+    function testForwardInsufficientBalance() public {
+        vm.prank(relayer);
+        vm.expectRevert(PaymentProxy.InsufficientBalance.selector);
+        proxy.forward(seller, address(usdc), 100_000, bytes32(0));
+    }
+
+    function testForwardEmitsEvent() public {
+        usdc.transfer(address(proxy), 500_000);
+        vm.prank(relayer);
+        vm.expectEmit(true, true, false, true);
+        emit PaymentForwarded(seller, address(usdc), 500_000, 0, bytes32(uint256(1)));
+        proxy.forward(seller, address(usdc), 500_000, bytes32(uint256(1)));
+    }
+
+    function testForwardZeroAmountReverts() public {
+        vm.prank(relayer);
+        vm.expectRevert(PaymentProxy.ZeroAmount.selector);
+        proxy.forward(seller, address(usdc), 0, bytes32(0));
+    }
+}

--- a/packages/contracts/src/PaymentProxy.ts
+++ b/packages/contracts/src/PaymentProxy.ts
@@ -1,0 +1,60 @@
+import { type PublicClient, type WalletClient, type Hex, keccak256, toBytes } from 'viem'
+
+export const PAYMENT_PROXY_ABI = [
+  {
+    name: 'forward',
+    type: 'function',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'seller', type: 'address' },
+      { name: 'token', type: 'address' },
+      { name: 'amount', type: 'uint256' },
+      { name: 'skillId', type: 'bytes32' },
+    ],
+    outputs: [],
+  },
+  {
+    name: 'feeBps',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [],
+    outputs: [{ type: 'uint16' }],
+  },
+  {
+    name: 'relayers',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [{ name: 'account', type: 'address' }],
+    outputs: [{ type: 'bool' }],
+  },
+] as const
+
+export class PaymentProxyClient {
+  constructor(
+    private address: Hex,
+    private pub: PublicClient,
+    private wallet?: WalletClient,
+  ) {}
+
+  async forward(seller: Hex, token: Hex, amount: bigint, skillId: string): Promise<Hex> {
+    if (!this.wallet?.account) throw new Error('Wallet required for forward()')
+    // UUIDs are 36 chars (with hyphens) which exceeds bytes32. Hash to fit.
+    const skillIdBytes32 = keccak256(toBytes(skillId))
+    const { request } = await this.pub.simulateContract({
+      address: this.address,
+      abi: PAYMENT_PROXY_ABI,
+      functionName: 'forward',
+      args: [seller, token, amount, skillIdBytes32],
+      account: this.wallet.account,
+    })
+    return this.wallet.writeContract(request)
+  }
+
+  async feeBps(): Promise<number> {
+    return this.pub.readContract({
+      address: this.address,
+      abi: PAYMENT_PROXY_ABI,
+      functionName: 'feeBps',
+    }) as Promise<number>
+  }
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -2,3 +2,4 @@ export { DataEscrow, type EscrowDetails, type EscrowConfig, EscrowState } from '
 export { ERC8004, type AgentProfile, type ReputationSummary } from './erc8004.js';
 export { ADDRESSES, TOKENS, type NetworkConfig } from './addresses.js';
 export { CONTRACT_ERRORS, decodeContractError, isContractError } from './errors.js';
+export { PaymentProxyClient, PAYMENT_PROXY_ABI } from './PaymentProxy.js';

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -8,7 +8,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@fairdrop/contracts": "workspace:*",
+    "@ade/contracts": "workspace:*",
     "ethers": "^6.13.0"
   },
   "devDependencies": {

--- a/packages/discovery/src/channels/erc8004.ts
+++ b/packages/discovery/src/channels/erc8004.ts
@@ -6,9 +6,9 @@
  */
 
 import { ethers, JsonRpcProvider } from 'ethers';
-import { ERC8004 } from '@fairdrop/contracts';
+import { ERC8004 } from '@ade/contracts';
 import { sanitize, type SanitizedOffering } from '../sanitize.js';
-import { ADDRESSES } from '@fairdrop/contracts';
+import { ADDRESSES } from '@ade/contracts';
 
 export class ERC8004Channel {
   private erc8004: ERC8004;

--- a/packages/discovery/src/channels/onchain.ts
+++ b/packages/discovery/src/channels/onchain.ts
@@ -7,7 +7,7 @@
  */
 
 import { ethers } from 'ethers';
-import { DataEscrow } from '@fairdrop/contracts';
+import { DataEscrow } from '@ade/contracts';
 import { sanitize, type SanitizedOffering } from '../sanitize.js';
 
 export interface OnChainSearchParams {

--- a/packages/discovery/src/search.ts
+++ b/packages/discovery/src/search.ts
@@ -15,7 +15,7 @@ import { type SanitizedOffering } from './sanitize.js';
 import { OnChainChannel } from './channels/onchain.js';
 import { MoltbookChannel } from './channels/moltbook.js';
 import { ERC8004Channel } from './channels/erc8004.js';
-import { DataEscrow } from '@fairdrop/contracts';
+import { DataEscrow } from '@ade/contracts';
 
 export interface SearchParams {
   /** Free-text query (matched against title, description, tags) */

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -32,12 +32,14 @@ import {
   watchCategoryTool,
   suggestPriceTool,
   marketSummaryTool,
-  // Composite (5)
+  // Composite (5 + 1 x402)
   sellTool,
   buyTool,
+  buyX402Tool,
   releaseKeyTool,
   claimTool,
   downloadContentTool,
+  downloadFreeTool,
   // Polling (2)
   waitForStateTool,
   myEscrowsTool,
@@ -82,12 +84,14 @@ const tools = [
   publishSkillTool,
   checkReputationTool,
   skillDetailsTool,
-  // Composite workflows (5)
+  // Composite workflows (5 + 1 x402)
   sellTool,
   buyTool,
+  buyX402Tool,
   releaseKeyTool,
   claimTool,
   downloadContentTool,
+  downloadFreeTool,
   // State & polling (2)
   waitForStateTool,
   myEscrowsTool,

--- a/packages/mcp/src/tools/buy-x402.ts
+++ b/packages/mcp/src/tools/buy-x402.ts
@@ -12,9 +12,9 @@
  */
 
 import { writeFileSync, mkdirSync } from 'fs'
-import { dirname } from 'path'
+import { dirname, resolve } from 'path'
 import { privateKeyToAccount } from 'viem/accounts'
-import type { Hex } from 'viem'
+import { isAddress, type Hex } from 'viem'
 import { session } from '../session.js'
 
 // --- Inlined helpers (from SDK, keep MCP self-contained) ---
@@ -30,16 +30,17 @@ function formatUsdc(smallestUnits: string): string {
   return `$${whole}.${display}`
 }
 
-// USDC contract on Base (EIP-3009 compatible)
-const USDC_BASE = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'
+// USDC contract addresses by network
+const NETWORK_CONFIG: Record<string, { chainId: number; usdcAddress: Hex }> = {
+  'eip155:8453': { chainId: 8453, usdcAddress: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913' },
+  'eip155:84532': { chainId: 84532, usdcAddress: '0x036CbD53842c5426634e7929541eC2318f3dCF7e' },
+}
 
-// EIP-712 domain for USDC on Base
-const USDC_EIP712_DOMAIN = {
-  name: 'USD Coin',
-  version: '2',
-  chainId: 8453,
-  verifyingContract: USDC_BASE as Hex,
-} as const
+function getNetworkConfig(network: string): { chainId: number; usdcAddress: Hex } {
+  const config = NETWORK_CONFIG[network]
+  if (!config) throw new Error(`Unsupported network: ${network}. Supported: ${Object.keys(NETWORK_CONFIG).join(', ')}`)
+  return config
+}
 
 // EIP-3009 TransferWithAuthorization types
 const TRANSFER_WITH_AUTHORIZATION_TYPES = {
@@ -129,7 +130,9 @@ export const buyX402Tool = {
     if (args.tx_hash) {
       const address = session.requireAddress()
 
-      const response = await fetch(`${downloadUrl}?tx_hash=${args.tx_hash}`, {
+      const redownloadUrl = new URL(downloadUrl)
+      redownloadUrl.searchParams.set('tx_hash', args.tx_hash)
+      const response = await fetch(redownloadUrl.toString(), {
         headers: {
           'X-Buyer-Address': address,
         },
@@ -144,13 +147,14 @@ export const buyX402Tool = {
       }
 
       const content = Buffer.from(await response.arrayBuffer())
-      mkdirSync(dirname(args.output_path), { recursive: true })
-      writeFileSync(args.output_path, content)
+      const resolvedPath = resolve(args.output_path)
+      mkdirSync(dirname(resolvedPath), { recursive: true })
+      writeFileSync(resolvedPath, content)
 
       return {
         success: true,
         skill_id: args.skill_id,
-        output_path: args.output_path,
+        output_path: resolvedPath,
         size_bytes: content.length,
         tx_hash: args.tx_hash,
         payment_amount: '0',
@@ -193,12 +197,13 @@ export const buyX402Tool = {
       if (initialRes.ok) {
         // Free content returned directly — unexpected for x402 skill
         const content = Buffer.from(await initialRes.arrayBuffer())
-        mkdirSync(dirname(args.output_path), { recursive: true })
-        writeFileSync(args.output_path, content)
+        const resolvedPath = resolve(args.output_path)
+        mkdirSync(dirname(resolvedPath), { recursive: true })
+        writeFileSync(resolvedPath, content)
         return {
           success: true,
           skill_id: args.skill_id,
-          output_path: args.output_path,
+          output_path: resolvedPath,
           size_bytes: content.length,
           tx_hash: '',
           payment_amount: '0',
@@ -223,9 +228,10 @@ export const buyX402Tool = {
       )
     }
 
-    // Find an "exact" scheme requirement for Base
+    // Find an "exact" scheme requirement for a supported network
+    const supportedNetworks = Object.keys(NETWORK_CONFIG)
     const req = requirements.find(r =>
-      r.scheme === 'exact' && (r.network === 'eip155:8453' || r.network === 'eip155:84532')
+      r.scheme === 'exact' && supportedNetworks.includes(r.network)
     ) || requirements[0]
 
     const paymentAmount = req.maxAmountRequired || req.amount || skill.price || '0'
@@ -234,6 +240,12 @@ export const buyX402Tool = {
     if (!payTo) {
       throw new Error('Payment requirement missing payTo address')
     }
+    if (!isAddress(payTo)) {
+      throw new Error(`Invalid payTo address from server: "${payTo}"`)
+    }
+
+    // Resolve chain-specific config (chainId + USDC address)
+    const networkConfig = getNetworkConfig(req.network)
 
     // Step 3: Sign EIP-3009 transferWithAuthorization
     const account = privateKeyToAccount(normalizedKey)
@@ -250,7 +262,12 @@ export const buyX402Tool = {
     }
 
     const signature = await account.signTypedData({
-      domain: USDC_EIP712_DOMAIN,
+      domain: {
+        name: 'USD Coin',
+        version: '2',
+        chainId: networkConfig.chainId,
+        verifyingContract: networkConfig.usdcAddress,
+      },
       types: TRANSFER_WITH_AUTHORIZATION_TYPES,
       primaryType: 'TransferWithAuthorization',
       message: authorization,
@@ -301,8 +318,9 @@ export const buyX402Tool = {
 
     // Step 6: Save content
     const content = Buffer.from(await paidRes.arrayBuffer())
-    mkdirSync(dirname(args.output_path), { recursive: true })
-    writeFileSync(args.output_path, content)
+    const resolvedPath = resolve(args.output_path)
+    mkdirSync(dirname(resolvedPath), { recursive: true })
+    writeFileSync(resolvedPath, content)
 
     // Extract tx hash from response header
     const txHash = paidRes.headers.get('X-Payment-TxHash') || ''
@@ -310,13 +328,13 @@ export const buyX402Tool = {
     return {
       success: true,
       skill_id: args.skill_id,
-      output_path: args.output_path,
+      output_path: resolvedPath,
       size_bytes: content.length,
       tx_hash: txHash,
       payment_amount: paymentAmount,
       payment_amount_formatted: formatUsdc(paymentAmount),
       next_steps: [
-        `Content saved to ${args.output_path} (${content.length} bytes)`,
+        `Content saved to ${resolvedPath} (${content.length} bytes)`,
         txHash ? `Transaction: ${txHash}` : 'Check marketplace for transaction details',
         `Re-download anytime with: df_buy_x402 skill_id="${args.skill_id}" tx_hash="${txHash}" output_path="..."`,
       ],

--- a/packages/mcp/src/tools/buy-x402.ts
+++ b/packages/mcp/src/tools/buy-x402.ts
@@ -1,0 +1,325 @@
+/**
+ * df_buy_x402 — purchase x402-priced skills via HTTP 402 payment protocol.
+ *
+ * Flow:
+ *   1. Fetch skill details from marketplace API
+ *   2. GET /skills/:id/download -> 402 with paymentRequirements
+ *   3. Sign EIP-3009 transferWithAuthorization for USDC on Base
+ *   4. Re-send GET with X-Payment header -> receive decrypted content
+ *   5. Save content to output_path
+ *
+ * Re-download: provide tx_hash to skip payment (uses X-Buyer-Address header).
+ */
+
+import { writeFileSync, mkdirSync } from 'fs'
+import { dirname } from 'path'
+import { privateKeyToAccount } from 'viem/accounts'
+import type { Hex } from 'viem'
+import { session } from '../session.js'
+
+// --- Inlined helpers (from SDK, keep MCP self-contained) ---
+
+function formatUsdc(smallestUnits: string): string {
+  const n = BigInt(smallestUnits || '0')
+  const whole = n / 1_000_000n
+  const frac = n % 1_000_000n
+  if (frac === 0n) return `$${whole}.00`
+  const fracStr = frac.toString().padStart(6, '0')
+  const trimmed = fracStr.replace(/0+$/, '')
+  const display = trimmed.length < 2 ? trimmed.padEnd(2, '0') : trimmed
+  return `$${whole}.${display}`
+}
+
+// USDC contract on Base (EIP-3009 compatible)
+const USDC_BASE = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'
+
+// EIP-712 domain for USDC on Base
+const USDC_EIP712_DOMAIN = {
+  name: 'USD Coin',
+  version: '2',
+  chainId: 8453,
+  verifyingContract: USDC_BASE as Hex,
+} as const
+
+// EIP-3009 TransferWithAuthorization types
+const TRANSFER_WITH_AUTHORIZATION_TYPES = {
+  TransferWithAuthorization: [
+    { name: 'from', type: 'address' },
+    { name: 'to', type: 'address' },
+    { name: 'value', type: 'uint256' },
+    { name: 'validAfter', type: 'uint256' },
+    { name: 'validBefore', type: 'uint256' },
+    { name: 'nonce', type: 'bytes32' },
+  ],
+} as const
+
+/**
+ * Create a random bytes32 nonce for EIP-3009.
+ */
+function randomNonce(): Hex {
+  const bytes = new Uint8Array(32)
+  crypto.getRandomValues(bytes)
+  return ('0x' + Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join('')) as Hex
+}
+
+// --- Types ---
+
+interface PaymentRequirement {
+  scheme: string
+  network: string
+  maxAmountRequired?: string
+  amount?: string
+  asset: string
+  payTo: string
+  description?: string
+  resource?: string
+  extra?: Record<string, unknown>
+  maxTimeoutSeconds?: number
+}
+
+interface PaymentRequiredResponse {
+  x402Version: number
+  paymentRequirements?: PaymentRequirement[]
+  accepts?: PaymentRequirement[]
+  error?: string
+}
+
+interface SkillDetails {
+  id: string
+  title: string
+  price?: string
+  payment_method?: string
+  seller?: string
+}
+
+// --- Tool definition ---
+
+export const buyX402Tool = {
+  name: 'df_buy_x402',
+  description:
+    'Purchase an x402-priced skill via HTTP 402 micropayment. Signs a USDC transferWithAuthorization on Base and downloads the decrypted content.',
+  inputSchema: {
+    type: 'object' as const,
+    properties: {
+      skill_id: {
+        type: 'string',
+        description: 'Marketplace skill ID to purchase',
+      },
+      output_path: {
+        type: 'string',
+        description: 'Local file path to save the downloaded content',
+      },
+      tx_hash: {
+        type: 'string',
+        description: 'Transaction hash from a previous purchase (re-download without paying again)',
+      },
+    },
+    required: ['skill_id', 'output_path'],
+  },
+
+  async execute(args: {
+    skill_id: string
+    output_path: string
+    tx_hash?: string
+  }) {
+    const MARKETPLACE_URL = process.env.MARKETPLACE_URL || 'https://agents.datafund.io'
+    const downloadUrl = `${MARKETPLACE_URL}/api/v1/skills/${args.skill_id}/download`
+
+    // --- Re-download path (skip payment) ---
+    if (args.tx_hash) {
+      const address = session.requireAddress()
+
+      const response = await fetch(`${downloadUrl}?tx_hash=${args.tx_hash}`, {
+        headers: {
+          'X-Buyer-Address': address,
+        },
+      })
+
+      if (!response.ok) {
+        const body = await response.text()
+        throw new Error(
+          `Re-download failed (${response.status}): ${body}. ` +
+          `Ensure the tx_hash is correct and X-Buyer-Address matches the original buyer.`
+        )
+      }
+
+      const content = Buffer.from(await response.arrayBuffer())
+      mkdirSync(dirname(args.output_path), { recursive: true })
+      writeFileSync(args.output_path, content)
+
+      return {
+        success: true,
+        skill_id: args.skill_id,
+        output_path: args.output_path,
+        size_bytes: content.length,
+        tx_hash: args.tx_hash,
+        payment_amount: '0',
+        payment_amount_formatted: 're-download (no charge)',
+        next_steps: [
+          'Content saved — verify the file contents',
+          'Use df_skill_details to check skill metadata',
+        ],
+      }
+    }
+
+    // --- New purchase path ---
+    const privateKey = session.requirePrivateKey()
+    const address = session.requireAddress()
+    const normalizedKey = (privateKey.startsWith('0x') ? privateKey : `0x${privateKey}`) as Hex
+
+    // Step 1: Fetch skill details to confirm it's an x402 skill
+    const detailsRes = await fetch(`${MARKETPLACE_URL}/api/v1/skills/${args.skill_id}`)
+    if (!detailsRes.ok) {
+      if (detailsRes.status === 404) {
+        throw new Error(`Skill not found: ${args.skill_id}`)
+      }
+      throw new Error(`Failed to fetch skill details (${detailsRes.status})`)
+    }
+    const skill = await detailsRes.json() as SkillDetails
+    if (skill.payment_method !== 'x402') {
+      throw new Error(
+        `Skill "${skill.title || args.skill_id}" uses payment method "${skill.payment_method}", not x402. ` +
+        (skill.payment_method === 'escrow'
+          ? 'Use df_buy for escrow-based purchases.'
+          : skill.payment_method === 'free'
+            ? 'Use df_download_free for free content.'
+            : 'This skill cannot be purchased with x402.')
+      )
+    }
+
+    // Step 2: GET download endpoint -> expect 402 with payment requirements
+    const initialRes = await fetch(downloadUrl)
+    if (initialRes.status !== 402) {
+      if (initialRes.ok) {
+        // Free content returned directly — unexpected for x402 skill
+        const content = Buffer.from(await initialRes.arrayBuffer())
+        mkdirSync(dirname(args.output_path), { recursive: true })
+        writeFileSync(args.output_path, content)
+        return {
+          success: true,
+          skill_id: args.skill_id,
+          output_path: args.output_path,
+          size_bytes: content.length,
+          tx_hash: '',
+          payment_amount: '0',
+          payment_amount_formatted: '$0.00 (free)',
+          next_steps: ['Content downloaded at no cost'],
+        }
+      }
+      const body = await initialRes.text()
+      throw new Error(
+        `Expected 402 Payment Required but got ${initialRes.status}: ${body}`
+      )
+    }
+
+    const paymentRequired = await initialRes.json() as PaymentRequiredResponse
+
+    // Extract payment requirements (support both field names from server)
+    const requirements = paymentRequired.paymentRequirements || paymentRequired.accepts
+    if (!requirements || requirements.length === 0) {
+      throw new Error(
+        'Server returned 402 but no payment requirements. ' +
+        `Response: ${JSON.stringify(paymentRequired).slice(0, 500)}`
+      )
+    }
+
+    // Find an "exact" scheme requirement for Base
+    const req = requirements.find(r =>
+      r.scheme === 'exact' && (r.network === 'eip155:8453' || r.network === 'eip155:84532')
+    ) || requirements[0]
+
+    const paymentAmount = req.maxAmountRequired || req.amount || skill.price || '0'
+    const payTo = req.payTo
+
+    if (!payTo) {
+      throw new Error('Payment requirement missing payTo address')
+    }
+
+    // Step 3: Sign EIP-3009 transferWithAuthorization
+    const account = privateKeyToAccount(normalizedKey)
+    const now = Math.floor(Date.now() / 1000)
+    const nonce = randomNonce()
+
+    const authorization = {
+      from: account.address,
+      to: payTo as Hex,
+      value: BigInt(paymentAmount),
+      validAfter: BigInt(0),
+      validBefore: BigInt(now + 3600), // 1 hour validity
+      nonce,
+    }
+
+    const signature = await account.signTypedData({
+      domain: USDC_EIP712_DOMAIN,
+      types: TRANSFER_WITH_AUTHORIZATION_TYPES,
+      primaryType: 'TransferWithAuthorization',
+      message: authorization,
+    })
+
+    // Step 4: Construct x402 payment payload
+    const paymentPayload = {
+      x402Version: 2,
+      scheme: 'exact',
+      network: req.network,
+      payload: {
+        signature,
+        authorization: {
+          from: authorization.from,
+          to: authorization.to,
+          value: paymentAmount,
+          validAfter: '0',
+          validBefore: (now + 3600).toString(),
+          nonce,
+        },
+      },
+    }
+
+    // Base64 encode for X-Payment header
+    const paymentHeader = Buffer.from(JSON.stringify(paymentPayload)).toString('base64')
+
+    // Step 5: Re-send download request with payment
+    const paidRes = await fetch(downloadUrl, {
+      headers: {
+        'X-Payment': paymentHeader,
+      },
+    })
+
+    if (paidRes.status === 402) {
+      const errorBody = await paidRes.json() as { error?: string; details?: string }
+      throw new Error(
+        `Payment rejected by facilitator: ${errorBody.details || errorBody.error || 'Unknown reason'}. ` +
+        `Amount: ${formatUsdc(paymentAmount)}, payTo: ${payTo}, from: ${account.address}`
+      )
+    }
+
+    if (!paidRes.ok) {
+      const body = await paidRes.text()
+      throw new Error(
+        `Download failed after payment (${paidRes.status}): ${body}`
+      )
+    }
+
+    // Step 6: Save content
+    const content = Buffer.from(await paidRes.arrayBuffer())
+    mkdirSync(dirname(args.output_path), { recursive: true })
+    writeFileSync(args.output_path, content)
+
+    // Extract tx hash from response header
+    const txHash = paidRes.headers.get('X-Payment-TxHash') || ''
+
+    return {
+      success: true,
+      skill_id: args.skill_id,
+      output_path: args.output_path,
+      size_bytes: content.length,
+      tx_hash: txHash,
+      payment_amount: paymentAmount,
+      payment_amount_formatted: formatUsdc(paymentAmount),
+      next_steps: [
+        `Content saved to ${args.output_path} (${content.length} bytes)`,
+        txHash ? `Transaction: ${txHash}` : 'Check marketplace for transaction details',
+        `Re-download anytime with: df_buy_x402 skill_id="${args.skill_id}" tx_hash="${txHash}" output_path="..."`,
+      ],
+    }
+  },
+}

--- a/packages/mcp/src/tools/buy.ts
+++ b/packages/mcp/src/tools/buy.ts
@@ -34,25 +34,30 @@ export const buyTool = {
     const privateKey = session.requirePrivateKey()
     const address = session.requireAddress()
 
-    // Check balance — fail fast if account can't pay
-    const publicClient = createPublicClient({
-      chain: base,
-      transport: http(process.env.BASE_RPC_URL || 'https://mainnet.base.org'),
-    })
-    const balance = await publicClient.getBalance({ address: address as `0x${string}` })
-    if (balance === 0n) {
-      throw new Error(
-        `Account ${address} has zero ETH on Base. You need Base ETH to fund escrows. ` +
-        `Bridge ETH to Base via https://bridge.base.org or get testnet ETH from a faucet.`
-      )
-    }
-
     let escrowId = args.escrow_id
     let encryptedDataRef: string | undefined
 
-    // If skill_id provided, look up escrow details
+    // If skill_id provided, check payment method before expensive balance check
     if (!escrowId && args.skill_id) {
       const MARKETPLACE_URL = process.env.MARKETPLACE_URL || 'https://agents.datafund.io'
+
+      // First check if this is an x402 skill — redirect to df_buy_x402
+      const skillResponse = await fetch(
+        `${MARKETPLACE_URL}/api/v1/skills/${args.skill_id}`
+      )
+      if (skillResponse.ok) {
+        const skill = await skillResponse.json() as { payment_method?: string; title?: string }
+        if (skill.payment_method === 'x402') {
+          return {
+            success: false,
+            error: `Skill "${skill.title || args.skill_id}" uses x402 instant payment, not escrow. ` +
+              `Use df_buy_x402 instead: df_buy_x402 skill_id="${args.skill_id}" output_path="./downloaded-content"`,
+            payment_method: 'x402',
+            redirect_tool: 'df_buy_x402',
+          }
+        }
+      }
+
       const detailsResponse = await fetch(
         `${MARKETPLACE_URL}/api/v1/skills/${args.skill_id}/purchase-info`
       )
@@ -81,6 +86,19 @@ export const buyTool = {
 
     if (!escrowId) {
       throw new Error('Provide escrow_id or skill_id')
+    }
+
+    // Check balance — fail fast if account can't pay gas for escrow
+    const publicClient = createPublicClient({
+      chain: base,
+      transport: http(process.env.BASE_RPC_URL || 'https://mainnet.base.org'),
+    })
+    const balance = await publicClient.getBalance({ address: address as `0x${string}` })
+    if (balance === 0n) {
+      throw new Error(
+        `Account ${address} has zero ETH on Base. You need Base ETH to fund escrows. ` +
+        `Bridge ETH to Base via https://bridge.base.org or get testnet ETH from a faucet.`
+      )
     }
 
     // If we have escrow_id but no encryptedDataRef, try to look it up from the marketplace

--- a/packages/mcp/src/tools/index.ts
+++ b/packages/mcp/src/tools/index.ts
@@ -36,9 +36,10 @@ export {
 // Composite workflows (5 tools)
 export { sellTool } from './sell.js'
 export { buyTool } from './buy.js'
+export { buyX402Tool } from './buy-x402.js'
 export { releaseKeyTool } from './release.js'
 export { claimTool } from './claim.js'
-export { downloadContentTool } from './download.js'
+export { downloadContentTool, downloadFreeTool } from './download.js'
 
 // Polling (2 tools)
 export { waitForStateTool, myEscrowsTool } from './polling.js'

--- a/packages/mcp/src/tools/sell.ts
+++ b/packages/mcp/src/tools/sell.ts
@@ -440,17 +440,42 @@ async function executeX402Sell(args: {
     )
   }
 
-  const marketplaceResult = await pubResponse.json()
+  const marketplaceResult = await pubResponse.json() as { id?: string }
+
+  // Backup content key locally (matches escrow key backup pattern)
+  let keyBackupFile: string | null = null
+  try {
+    const keysDir = path.join(
+      process.env.HOME || process.env.USERPROFILE || '.',
+      '.datafund', 'x402-keys'
+    )
+    fs.mkdirSync(keysDir, { recursive: true, mode: 0o700 })
+    const skillId = marketplaceResult.id || uploadResult.reference
+    keyBackupFile = path.join(keysDir, `x402-${skillId}.json`)
+    fs.writeFileSync(keyBackupFile, JSON.stringify({
+      skillId,
+      contentKey: keyHex,
+      encryptedDataRef: uploadResult.reference,
+      contentHash,
+      seller: address,
+      createdAt: new Date().toISOString(),
+    }, null, 2), { mode: 0o600 })
+  } catch (err) {
+    keyBackupFile = `FAILED: ${err instanceof Error ? err.message : String(err)}`
+  }
 
   return {
     success: true,
     payment_method: 'x402',
     contentHash,
     encryptedDataRef: uploadResult.reference,
+    keyBackupFile,
     marketplace: marketplaceResult,
     next_steps: [
       'Skill is now listed with x402 instant payment',
       'Buyers pay via HTTP 402 micropayment — no escrow needed',
+      'Note: the marketplace server holds the decryption key for serving content',
+      `Content key backed up to ${keyBackupFile}`,
       'Use df_skill_details to check listing status',
     ],
   }

--- a/packages/mcp/src/tools/sell.ts
+++ b/packages/mcp/src/tools/sell.ts
@@ -2,6 +2,7 @@ import { createPublicClient, http, formatEther, decodeEventLog, keccak256 } from
 import { base } from 'viem/chains'
 import * as fs from 'fs'
 import * as path from 'path'
+import * as crypto from 'crypto'
 import { session } from '../session.js'
 import { callRemoteTool } from '../proxy.js'
 import { verifyTransaction, type UnsignedTx } from '../tx-verify.js'
@@ -32,7 +33,7 @@ const ESCROW_CREATED_EVENT = {
 
 export const sellTool = {
   name: 'df_sell',
-  description: 'Composite: Upload content → create escrow → sign → submit → publish to marketplace. Single call to list content for sale.',
+  description: 'Composite: Upload content and list for sale. Supports escrow (on-chain, default) or x402 (instant USDC micropayment).',
   inputSchema: {
     type: 'object' as const,
     properties: {
@@ -46,7 +47,7 @@ export const sellTool = {
       },
       price_wei: {
         type: 'string',
-        description: 'Price in wei',
+        description: 'Price in wei (escrow) or USDC smallest units (x402, e.g. "1000000" for $1.00)',
       },
       name: {
         type: 'string',
@@ -62,12 +63,16 @@ export const sellTool = {
       },
       expiry_days: {
         type: 'number',
-        description: 'Escrow expiry in days (default: 7)',
+        description: 'Escrow expiry in days (default: 7). Ignored for x402.',
       },
       tags: {
         type: 'array',
         items: { type: 'string' },
         description: 'Tags for marketplace discovery',
+      },
+      payment_method: {
+        type: 'string',
+        description: 'Payment method: "escrow" (default, on-chain) or "x402" (instant USDC micropayment)',
       },
     },
     required: ['price_wei', 'name', 'description', 'category'],
@@ -81,7 +86,14 @@ export const sellTool = {
     category: string
     expiry_days?: number
     tags?: string[]
+    payment_method?: string
   }) {
+    // Route to x402 flow if specified
+    if (args.payment_method === 'x402') {
+      return executeX402Sell(args)
+    }
+
+    // Default: escrow flow (existing behavior)
     const privateKey = session.requirePrivateKey()
     const address = session.requireAddress()
 
@@ -277,26 +289,29 @@ export const sellTool = {
       keyFilePath = `FAILED: ${err instanceof Error ? err.message : String(err)}`
     }
 
-    // Step 7: Publish to marketplace
+    // Step 7: Publish to marketplace (signed)
     let marketplaceResult: unknown = null
     let marketplaceError: string | null = null
     try {
+      const { signRequest } = await import('../signing.js')
       const MARKETPLACE_URL = process.env.MARKETPLACE_URL || 'https://agents.datafund.io'
+      const pubBody: Record<string, unknown> = {
+        seller: address,
+        title: args.name,
+        description: args.description,
+        category: args.category,
+        price: args.price_wei,
+        priceToken: 'ETH',
+        escrowId: parseInt(escrowId, 10),
+        contentHash: prepareResult.contentHash,
+        encryptedDataRef: prepareResult.encryptedDataRef,
+        tags: args.tags || [],
+      }
+      const headers = signRequest(pubBody, privateKey)
       const pubResponse = await fetch(`${MARKETPLACE_URL}/api/v1/skills`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          seller: address,
-          title: args.name,
-          description: args.description,
-          category: args.category,
-          price: args.price_wei,
-          priceToken: 'ETH',
-          escrowId: parseInt(escrowId, 10),
-          contentHash: prepareResult.contentHash,
-          encryptedDataRef: prepareResult.encryptedDataRef,
-          tags: args.tags || [],
-        }),
+        headers,
+        body: JSON.stringify(pubBody),
       })
       if (pubResponse.ok) {
         marketplaceResult = await pubResponse.json()
@@ -327,6 +342,118 @@ export const sellTool = {
       ],
     }
   },
+}
+
+/**
+ * x402 sell flow: encrypt content locally, upload to Swarm, publish to marketplace.
+ * No escrow, no on-chain transaction. The marketplace server stores the content key
+ * and serves content via HTTP 402 micropayments.
+ */
+async function executeX402Sell(args: {
+  content_base64?: string
+  file_path?: string
+  price_wei: string
+  name: string
+  description: string
+  category: string
+  tags?: string[]
+}) {
+  const privateKey = session.requirePrivateKey()
+  const address = session.requireAddress()
+
+  // Step 1: Read content
+  let content: Buffer
+  if (args.content_base64) {
+    content = Buffer.from(args.content_base64, 'base64')
+  } else if (args.file_path) {
+    content = fs.readFileSync(args.file_path)
+  } else {
+    throw new Error('Provide content_base64 or file_path')
+  }
+
+  if (content.length === 0) {
+    throw new Error('Content is empty — nothing to sell')
+  }
+
+  // Step 2: Encrypt with AES-256-GCM (same format as escrow flow)
+  const key = crypto.randomBytes(32)
+  const iv = crypto.randomBytes(12)
+  const cipher = crypto.createCipheriv('aes-256-gcm', key, iv)
+  const ct = Buffer.concat([cipher.update(content), cipher.final()])
+  const tag = cipher.getAuthTag()
+  // Format: IV(12) + authTag(16) + ciphertext
+  const encrypted = Buffer.concat([iv, tag, ct])
+  const keyHex = key.toString('hex')
+
+  // Step 3: Upload encrypted content to Swarm
+  const uploadResult = await callRemoteTool('fairdrop_upload_bytes', {
+    data_base64: encrypted.toString('base64'),
+  }) as { reference: string }
+
+  if (!uploadResult.reference) {
+    throw new Error(
+      'Swarm upload did not return a reference. Check the Bee node connection and postage stamp balance.'
+    )
+  }
+
+  // Step 4: Compute content hash (keccak256 of encrypted content)
+  const contentHash = keccak256(new Uint8Array(encrypted))
+
+  // Step 5: Verify upload is retrievable
+  const verified = await verifySwarmUpload(uploadResult.reference, contentHash)
+  if (!verified) {
+    throw new Error(
+      `Swarm upload verification failed. The encrypted content (ref: ${uploadResult.reference}) could not be downloaded back. ` +
+      'Check postage stamp balance and Bee node connectivity.'
+    )
+  }
+
+  // Step 6: Publish to marketplace with x402 payment method
+  const { signRequest } = await import('../signing.js')
+  const MARKETPLACE_URL = process.env.MARKETPLACE_URL || 'https://agents.datafund.io'
+
+  const pubBody: Record<string, unknown> = {
+    seller: address,
+    title: args.name,
+    description: args.description,
+    category: args.category,
+    price: args.price_wei,
+    priceToken: 'USDC',
+    tags: args.tags || [],
+    contentHash,
+    encryptedDataRef: uploadResult.reference,
+    payment_method: 'x402',
+    x402_content_key: keyHex,
+  }
+
+  const headers = signRequest(pubBody, privateKey)
+  const pubResponse = await fetch(`${MARKETPLACE_URL}/api/v1/skills`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(pubBody),
+  })
+
+  if (!pubResponse.ok) {
+    const errorBody = await pubResponse.text()
+    throw new Error(
+      `Marketplace publish failed (${pubResponse.status}): ${errorBody}`
+    )
+  }
+
+  const marketplaceResult = await pubResponse.json()
+
+  return {
+    success: true,
+    payment_method: 'x402',
+    contentHash,
+    encryptedDataRef: uploadResult.reference,
+    marketplace: marketplaceResult,
+    next_steps: [
+      'Skill is now listed with x402 instant payment',
+      'Buyers pay via HTTP 402 micropayment — no escrow needed',
+      'Use df_skill_details to check listing status',
+    ],
+  }
 }
 
 /**

--- a/packages/mcp/test/buy-x402-detection.test.ts
+++ b/packages/mcp/test/buy-x402-detection.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// Mock fetch globally
+const mockFetch = vi.fn()
+global.fetch = mockFetch
+
+// Mock session
+vi.mock('../src/session.js', () => ({
+  session: {
+    privateKey: '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
+    address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+    publicKey: '04abcdef1234567890',
+    requirePrivateKey: vi.fn(() => '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'),
+    requireAddress: vi.fn(() => '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'),
+    setEscrow: vi.fn(),
+  },
+}))
+
+// Mock proxy (callRemoteTool)
+vi.mock('../src/proxy.js', () => ({
+  callRemoteTool: vi.fn(),
+}))
+
+// Mock tx-verify
+vi.mock('../src/tx-verify.js', () => ({
+  verifyTransaction: vi.fn(),
+}))
+
+// Mock signing tool
+vi.mock('../src/tools/signing.js', () => ({
+  signTransactionTool: {
+    execute: vi.fn(),
+  },
+}))
+
+// Import AFTER mocks
+import { buyTool } from '../src/tools/buy.js'
+
+// --- Test fixtures ---
+
+const SKILL_ID = 'test-skill-x402'
+
+// --- Tests ---
+
+describe('df_buy x402 detection', () => {
+  beforeEach(() => {
+    mockFetch.mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should detect x402 skill and return redirect message', async () => {
+    // GET /skills/:id -> x402 skill
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({
+        id: SKILL_ID,
+        title: 'x402 Research Paper',
+        payment_method: 'x402',
+        price: '1000000',
+      }),
+    })
+
+    const result = await buyTool.execute({
+      skill_id: SKILL_ID,
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('x402')
+    expect(result.error).toContain('df_buy_x402')
+    expect(result.error).toContain(SKILL_ID)
+    expect(result.payment_method).toBe('x402')
+    expect(result.redirect_tool).toBe('df_buy_x402')
+
+    // Should have only made one fetch call (skill details check)
+    // No balance check, no purchase-info — early return
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(mockFetch.mock.calls[0][0]).toContain(`/api/v1/skills/${SKILL_ID}`)
+  })
+
+  it('should include skill title in redirect message', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({
+        id: SKILL_ID,
+        title: 'My Cool Dataset',
+        payment_method: 'x402',
+      }),
+    })
+
+    const result = await buyTool.execute({
+      skill_id: SKILL_ID,
+    })
+
+    expect(result.error).toContain('My Cool Dataset')
+  })
+
+  it('should continue to escrow flow when skill is not x402', async () => {
+    // Call 1: GET /skills/:id -> escrow skill
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({
+        id: SKILL_ID,
+        title: 'Escrow Skill',
+        payment_method: 'escrow',
+      }),
+    })
+
+    // Call 2: purchase-info
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({
+        escrow_id: '42',
+        seller_address: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+        encrypted_data_ref: 'someref',
+      }),
+    })
+
+    // After purchase-info, the escrow flow calls getBalance via viem (uses fetch internally).
+    // viem will fail because our mock doesn't return proper RPC responses.
+    // This proves we entered the escrow branch (not redirected to x402).
+    await expect(
+      buyTool.execute({ skill_id: SKILL_ID })
+    ).rejects.toThrow()
+
+    // First two calls should be skill details + purchase-info
+    expect(mockFetch.mock.calls[0][0]).toContain(`/api/v1/skills/${SKILL_ID}`)
+    expect(mockFetch.mock.calls[1][0]).toContain('/purchase-info')
+  })
+
+  it('should continue gracefully when skill lookup fails', async () => {
+    // Call 1: GET /skills/:id -> 500 error
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+    })
+
+    // Call 2: purchase-info (fallback path)
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({
+        escrow_id: '42',
+        seller_address: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+      }),
+    })
+
+    // Escrow flow continues and will fail at getBalance RPC call
+    await expect(
+      buyTool.execute({ skill_id: SKILL_ID })
+    ).rejects.toThrow()
+
+    // First two fetches should be skill lookup (failed) + purchase-info
+    expect(mockFetch.mock.calls[0][0]).toContain(`/api/v1/skills/${SKILL_ID}`)
+    expect(mockFetch.mock.calls[1][0]).toContain('/purchase-info')
+  })
+
+  it('should not check for x402 when escrow_id is provided directly', async () => {
+    // When escrow_id is given, skip skill lookup entirely — go straight to escrow flow.
+    // The escrow flow calls getBalance via viem (which uses fetch internally).
+    // We verify no /api/v1/skills/ calls were made.
+    await expect(
+      buyTool.execute({ escrow_id: '42' })
+    ).rejects.toThrow()
+
+    // Verify none of the fetch calls were to /api/v1/skills/
+    // (viem RPC calls go to mainnet.base.org, not our marketplace)
+    const skillCalls = mockFetch.mock.calls.filter(
+      (call: any) => typeof call[0] === 'string' && call[0].includes('/api/v1/skills/')
+    )
+    expect(skillCalls).toHaveLength(0)
+  })
+
+  it('should handle skill with no payment_method field', async () => {
+    // Call 1: GET /skills/:id -> skill without payment_method
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({
+        id: SKILL_ID,
+        title: 'Legacy Skill',
+        // no payment_method field
+      }),
+    })
+
+    // Call 2: purchase-info
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({
+        escrow_id: '99',
+        seller_address: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+      }),
+    })
+
+    // Should fall through to escrow flow (not redirect)
+    await expect(
+      buyTool.execute({ skill_id: SKILL_ID })
+    ).rejects.toThrow()
+
+    // First two fetches: skill details + purchase-info
+    expect(mockFetch.mock.calls[0][0]).toContain(`/api/v1/skills/${SKILL_ID}`)
+    expect(mockFetch.mock.calls[1][0]).toContain('/purchase-info')
+  })
+})

--- a/packages/mcp/test/buy-x402.test.ts
+++ b/packages/mcp/test/buy-x402.test.ts
@@ -1,0 +1,372 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// Mock fetch globally
+const mockFetch = vi.fn()
+global.fetch = mockFetch
+
+// Mock fs
+vi.mock('fs', () => ({
+  writeFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+}))
+
+// Mock session — vi.mock factories are hoisted so cannot reference outer variables
+vi.mock('../src/session.js', () => ({
+  session: {
+    privateKey: '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
+    address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+    requirePrivateKey: vi.fn(() => '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'),
+    requireAddress: vi.fn(() => '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'),
+  },
+}))
+
+// Note: signing.js is not imported by buy-x402 (x402 uses X-Payment header, not EIP-191)
+
+// Import the tool AFTER mocks are set up
+import { buyX402Tool } from '../src/tools/buy-x402.js'
+import { session } from '../src/session.js'
+
+// --- Test fixtures ---
+
+const TEST_ADDRESS = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
+const SKILL_ID = 'test-skill-123'
+const OUTPUT_PATH = '/tmp/test-output.tar.gz'
+const SELLER = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8'
+const PRICE = '1000000' // 1 USDC in smallest units
+const TX_HASH = '0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab'
+
+const skillDetailsResponse = {
+  id: SKILL_ID,
+  title: 'Test Skill',
+  price: PRICE,
+  payment_method: 'x402',
+  seller: SELLER,
+}
+
+const paymentRequiredResponse = {
+  x402Version: 2,
+  paymentRequirements: [{
+    scheme: 'exact',
+    network: 'eip155:8453',
+    maxAmountRequired: PRICE,
+    resource: `/api/v1/skills/${SKILL_ID}/download`,
+    description: `Purchase skill: ${SKILL_ID}`,
+    payTo: '0x1234567890123456789012345678901234567890',
+    asset: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+    extra: { seller: SELLER, skillId: SKILL_ID },
+  }],
+}
+
+function makeContentBuffer() {
+  return Buffer.from('test content payload for skill download')
+}
+
+function mockContentResponse(txHash?: string) {
+  const buf = makeContentBuffer()
+  return {
+    ok: true,
+    status: 200,
+    arrayBuffer: () => Promise.resolve(buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength)),
+    headers: {
+      get: (name: string) => {
+        if (name === 'X-Payment-TxHash') return txHash || TX_HASH
+        return null
+      },
+    },
+  }
+}
+
+// --- Tests ---
+
+describe('df_buy_x402', () => {
+  beforeEach(() => {
+    mockFetch.mockReset()
+    // Reset session mocks to default behavior
+    vi.mocked(session.requirePrivateKey).mockReturnValue(
+      '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
+    )
+    vi.mocked(session.requireAddress).mockReturnValue(TEST_ADDRESS)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should have correct tool metadata', () => {
+    expect(buyX402Tool.name).toBe('df_buy_x402')
+    expect(buyX402Tool.inputSchema.required).toEqual(['skill_id', 'output_path'])
+    expect(buyX402Tool.inputSchema.properties).toHaveProperty('skill_id')
+    expect(buyX402Tool.inputSchema.properties).toHaveProperty('output_path')
+    expect(buyX402Tool.inputSchema.properties).toHaveProperty('tx_hash')
+  })
+
+  describe('successful x402 purchase', () => {
+    it('should complete the full purchase flow', async () => {
+      // Call 1: GET /skills/:id -> skill details
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(skillDetailsResponse),
+      })
+
+      // Call 2: GET /skills/:id/download -> 402 with payment requirements
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 402,
+        json: () => Promise.resolve(paymentRequiredResponse),
+      })
+
+      // Call 3: GET /skills/:id/download with X-Payment -> 200 with content
+      mockFetch.mockResolvedValueOnce(mockContentResponse())
+
+      const result = await buyX402Tool.execute({
+        skill_id: SKILL_ID,
+        output_path: OUTPUT_PATH,
+      })
+
+      expect(result.success).toBe(true)
+      expect(result.skill_id).toBe(SKILL_ID)
+      expect(result.output_path).toBe(OUTPUT_PATH)
+      expect(result.size_bytes).toBe(makeContentBuffer().length)
+      expect(result.payment_amount).toBe(PRICE)
+      expect(result.payment_amount_formatted).toBe('$1.00')
+      expect(result.tx_hash).toBe(TX_HASH)
+      expect(Array.isArray(result.next_steps)).toBe(true)
+
+      // Verify fetch calls
+      expect(mockFetch).toHaveBeenCalledTimes(3)
+
+      // Call 1: skill details
+      expect(mockFetch.mock.calls[0][0]).toContain(`/api/v1/skills/${SKILL_ID}`)
+
+      // Call 2: initial download (no payment header)
+      expect(mockFetch.mock.calls[1][0]).toContain(`/api/v1/skills/${SKILL_ID}/download`)
+
+      // Call 3: download with payment
+      const paidCall = mockFetch.mock.calls[2]
+      expect(paidCall[0]).toContain(`/api/v1/skills/${SKILL_ID}/download`)
+      expect(paidCall[1].headers['X-Payment']).toBeDefined()
+
+      // Verify the payment header is valid base64 containing correct payload
+      const decoded = JSON.parse(Buffer.from(paidCall[1].headers['X-Payment'], 'base64').toString())
+      expect(decoded.x402Version).toBe(2)
+      expect(decoded.scheme).toBe('exact')
+      expect(decoded.payload.signature).toBeDefined()
+      expect(decoded.payload.authorization).toBeDefined()
+      expect(decoded.payload.authorization.from).toBe(TEST_ADDRESS)
+    })
+  })
+
+  describe('re-download with tx_hash', () => {
+    it('should skip payment and download with X-Buyer-Address', async () => {
+      mockFetch.mockResolvedValueOnce(mockContentResponse())
+
+      const result = await buyX402Tool.execute({
+        skill_id: SKILL_ID,
+        output_path: OUTPUT_PATH,
+        tx_hash: TX_HASH,
+      })
+
+      expect(result.success).toBe(true)
+      expect(result.tx_hash).toBe(TX_HASH)
+      expect(result.payment_amount).toBe('0')
+      expect(result.payment_amount_formatted).toBe('re-download (no charge)')
+
+      // Should only make one fetch call (no skill details or payment)
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+
+      // Verify re-download URL and headers
+      const call = mockFetch.mock.calls[0]
+      expect(call[0]).toContain(`tx_hash=${TX_HASH}`)
+      expect(call[1].headers['X-Buyer-Address']).toBe(TEST_ADDRESS)
+    })
+
+    it('should throw on failed re-download', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        text: () => Promise.resolve('Buyer address does not match'),
+      })
+
+      await expect(
+        buyX402Tool.execute({
+          skill_id: SKILL_ID,
+          output_path: OUTPUT_PATH,
+          tx_hash: TX_HASH,
+        })
+      ).rejects.toThrow('Re-download failed')
+    })
+  })
+
+  describe('error: skill not found', () => {
+    it('should throw when skill does not exist', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+      })
+
+      await expect(
+        buyX402Tool.execute({
+          skill_id: 'nonexistent',
+          output_path: OUTPUT_PATH,
+        })
+      ).rejects.toThrow('Skill not found: nonexistent')
+    })
+  })
+
+  describe('error: skill is not x402', () => {
+    it('should throw when skill uses escrow payment method', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({
+          ...skillDetailsResponse,
+          payment_method: 'escrow',
+        }),
+      })
+
+      await expect(
+        buyX402Tool.execute({
+          skill_id: SKILL_ID,
+          output_path: OUTPUT_PATH,
+        })
+      ).rejects.toThrow('Use df_buy for escrow-based purchases')
+    })
+
+    it('should throw when skill uses free payment method', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({
+          ...skillDetailsResponse,
+          payment_method: 'free',
+        }),
+      })
+
+      await expect(
+        buyX402Tool.execute({
+          skill_id: SKILL_ID,
+          output_path: OUTPUT_PATH,
+        })
+      ).rejects.toThrow('Use df_download_free for free content')
+    })
+  })
+
+  describe('error: payment rejected by facilitator', () => {
+    it('should throw when 402 is returned again after payment', async () => {
+      // Call 1: skill details
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(skillDetailsResponse),
+      })
+
+      // Call 2: initial 402
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 402,
+        json: () => Promise.resolve(paymentRequiredResponse),
+      })
+
+      // Call 3: payment rejected — still 402
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 402,
+        json: () => Promise.resolve({
+          error: 'Payment verification failed',
+          details: 'Insufficient USDC balance',
+          ...paymentRequiredResponse,
+        }),
+      })
+
+      await expect(
+        buyX402Tool.execute({
+          skill_id: SKILL_ID,
+          output_path: OUTPUT_PATH,
+        })
+      ).rejects.toThrow('Payment rejected by facilitator: Insufficient USDC balance')
+    })
+  })
+
+  describe('error: no private key in session', () => {
+    it('should throw when session has no private key', async () => {
+      vi.mocked(session.requirePrivateKey).mockImplementation(() => {
+        throw new Error(
+          'No private key in session. Use df_generate_keypair, df_wallet_from_mnemonic, or df_decrypt_keystore first.'
+        )
+      })
+
+      await expect(
+        buyX402Tool.execute({
+          skill_id: SKILL_ID,
+          output_path: OUTPUT_PATH,
+        })
+      ).rejects.toThrow('No private key in session')
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should handle payment requirements with "accepts" field (v2 format)', async () => {
+      // Call 1: skill details
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(skillDetailsResponse),
+      })
+
+      // Call 2: 402 with "accepts" field instead of "paymentRequirements"
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 402,
+        json: () => Promise.resolve({
+          x402Version: 2,
+          accepts: paymentRequiredResponse.paymentRequirements,
+        }),
+      })
+
+      // Call 3: successful download
+      mockFetch.mockResolvedValueOnce(mockContentResponse())
+
+      const result = await buyX402Tool.execute({
+        skill_id: SKILL_ID,
+        output_path: OUTPUT_PATH,
+      })
+
+      expect(result.success).toBe(true)
+    })
+
+    it('should handle "amount" field in requirements (v2 standard)', async () => {
+      // Call 1: skill details
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(skillDetailsResponse),
+      })
+
+      // Call 2: 402 with "amount" instead of "maxAmountRequired"
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 402,
+        json: () => Promise.resolve({
+          x402Version: 2,
+          paymentRequirements: [{
+            ...paymentRequiredResponse.paymentRequirements![0],
+            maxAmountRequired: undefined,
+            amount: PRICE,
+          }],
+        }),
+      })
+
+      // Call 3: successful download
+      mockFetch.mockResolvedValueOnce(mockContentResponse())
+
+      const result = await buyX402Tool.execute({
+        skill_id: SKILL_ID,
+        output_path: OUTPUT_PATH,
+      })
+
+      expect(result.success).toBe(true)
+      expect(result.payment_amount).toBe(PRICE)
+    })
+  })
+})

--- a/packages/mcp/test/sell-x402.test.ts
+++ b/packages/mcp/test/sell-x402.test.ts
@@ -142,7 +142,8 @@ describe('df_sell with payment_method: x402', () => {
       expect(result).not.toHaveProperty('escrowId')
       expect(result).not.toHaveProperty('txHash')
       expect(result).not.toHaveProperty('encryptionKey')
-      expect(result).not.toHaveProperty('keyBackupFile')
+      // x402 flow has its own key backup (not escrow key backup)
+      expect(result).toHaveProperty('keyBackupFile')
 
       // Verify Swarm upload was called
       expect(mockCallRemoteTool).toHaveBeenCalledWith('fairdrop_upload_bytes', {

--- a/packages/mcp/test/sell-x402.test.ts
+++ b/packages/mcp/test/sell-x402.test.ts
@@ -1,0 +1,366 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import * as crypto from 'crypto'
+
+// Mock fetch globally
+const mockFetch = vi.fn()
+global.fetch = mockFetch
+
+// Mock fs
+const mockWriteFileSync = vi.fn()
+const mockMkdirSync = vi.fn()
+const mockReadFileSync = vi.fn()
+vi.mock('fs', () => ({
+  writeFileSync: (...args: any[]) => mockWriteFileSync(...args),
+  mkdirSync: (...args: any[]) => mockMkdirSync(...args),
+  readFileSync: (...args: any[]) => mockReadFileSync(...args),
+}))
+
+// Mock session
+vi.mock('../src/session.js', () => ({
+  session: {
+    privateKey: '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
+    address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+    requirePrivateKey: vi.fn(() => '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'),
+    requireAddress: vi.fn(() => '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'),
+    setEscrow: vi.fn(),
+  },
+}))
+
+// Mock proxy (callRemoteTool) — needed for Swarm upload + download verification
+const mockCallRemoteTool = vi.fn()
+vi.mock('../src/proxy.js', () => ({
+  callRemoteTool: (...args: any[]) => mockCallRemoteTool(...args),
+}))
+
+// Mock tx-verify — not used in x402 flow but imported by sell.ts
+vi.mock('../src/tx-verify.js', () => ({
+  verifyTransaction: vi.fn(),
+}))
+
+// Mock signing tool — not used in x402 flow but imported by sell.ts
+vi.mock('../src/tools/signing.js', () => ({
+  signTransactionTool: {
+    execute: vi.fn(),
+  },
+}))
+
+// Mock signing.js (EIP-191) — used for marketplace publish
+vi.mock('../src/signing.js', () => ({
+  signRequest: vi.fn(() => ({
+    'Content-Type': 'application/json',
+    'X-Address': '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+    'X-Signature': '0xmocksig',
+    'X-Timestamp': '1234567890',
+    'X-Nonce': 'mock-nonce',
+  })),
+}))
+
+// Import AFTER mocks
+import { sellTool } from '../src/tools/sell.js'
+
+// --- Test fixtures ---
+
+const TEST_ADDRESS = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
+const SWARM_REF = 'abc123def456abc123def456abc123def456abc123def456abc123def456abc1'
+const PRICE_USDC = '1000000' // 1 USDC
+const TEST_CONTENT = 'Hello, this is test content for x402 sale'
+const TEST_CONTENT_BASE64 = Buffer.from(TEST_CONTENT).toString('base64')
+
+function makeUploadResponse() {
+  return { reference: SWARM_REF }
+}
+
+function makeDownloadResponse(encryptedBase64: string) {
+  return {
+    data_base64: encryptedBase64,
+    size: Buffer.from(encryptedBase64, 'base64').length,
+  }
+}
+
+// --- Tests ---
+
+describe('df_sell with payment_method: x402', () => {
+  let capturedUploadData: string | null = null
+
+  beforeEach(() => {
+    mockFetch.mockReset()
+    mockCallRemoteTool.mockReset()
+    mockReadFileSync.mockReset()
+    capturedUploadData = null
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should have updated tool metadata with payment_method property', () => {
+    expect(sellTool.inputSchema.properties).toHaveProperty('payment_method')
+    expect(sellTool.inputSchema.properties.payment_method.type).toBe('string')
+  })
+
+  describe('successful x402 sell from content_base64', () => {
+    it('should encrypt, upload, and publish without escrow', async () => {
+      // Mock callRemoteTool: upload returns Swarm ref, download verifies
+      mockCallRemoteTool.mockImplementation(async (name: string, args: any) => {
+        if (name === 'fairdrop_upload_bytes') {
+          capturedUploadData = args.data_base64
+          return makeUploadResponse()
+        }
+        if (name === 'fairdrop_download_bytes') {
+          // Return the same data that was uploaded (for verification)
+          return makeDownloadResponse(capturedUploadData!)
+        }
+        throw new Error(`Unexpected tool call: ${name}`)
+      })
+
+      // Mock marketplace publish
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ id: 'skill-001', status: 'active' }),
+      })
+
+      const result = await sellTool.execute({
+        content_base64: TEST_CONTENT_BASE64,
+        price_wei: PRICE_USDC,
+        name: 'Test Skill',
+        description: 'A test skill for x402',
+        category: 'research',
+        tags: ['test', 'x402'],
+        payment_method: 'x402',
+      })
+
+      expect(result.success).toBe(true)
+      expect(result.payment_method).toBe('x402')
+      expect(result.contentHash).toBeDefined()
+      expect(result.contentHash).toMatch(/^0x[0-9a-f]{64}$/i)
+      expect(result.encryptedDataRef).toBe(SWARM_REF)
+      expect(result.marketplace).toEqual({ id: 'skill-001', status: 'active' })
+      expect(Array.isArray(result.next_steps)).toBe(true)
+
+      // Verify no escrow-related fields
+      expect(result).not.toHaveProperty('escrowId')
+      expect(result).not.toHaveProperty('txHash')
+      expect(result).not.toHaveProperty('encryptionKey')
+      expect(result).not.toHaveProperty('keyBackupFile')
+
+      // Verify Swarm upload was called
+      expect(mockCallRemoteTool).toHaveBeenCalledWith('fairdrop_upload_bytes', {
+        data_base64: expect.any(String),
+      })
+
+      // Verify the uploaded data is encrypted (not plaintext)
+      expect(capturedUploadData).toBeDefined()
+      const uploadedBytes = Buffer.from(capturedUploadData!, 'base64')
+      // AES-256-GCM: IV(12) + authTag(16) + ciphertext
+      expect(uploadedBytes.length).toBeGreaterThan(12 + 16)
+      // The encrypted data should NOT contain the plaintext
+      expect(uploadedBytes.toString()).not.toContain(TEST_CONTENT)
+
+      // Verify marketplace publish was called with correct body
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      const [publishUrl, publishOpts] = mockFetch.mock.calls[0]
+      expect(publishUrl).toContain('/api/v1/skills')
+      const body = JSON.parse(publishOpts.body)
+      expect(body.payment_method).toBe('x402')
+      expect(body.x402_content_key).toBeDefined()
+      expect(body.x402_content_key).toHaveLength(64) // 32 bytes = 64 hex chars
+      expect(body.priceToken).toBe('USDC')
+      expect(body.price).toBe(PRICE_USDC)
+      expect(body.seller).toBe(TEST_ADDRESS)
+      expect(body.title).toBe('Test Skill')
+      expect(body.tags).toEqual(['test', 'x402'])
+      expect(body.contentHash).toBeDefined()
+      expect(body.encryptedDataRef).toBe(SWARM_REF)
+
+      // Verify the content key can actually decrypt the uploaded data
+      const keyBuf = Buffer.from(body.x402_content_key, 'hex')
+      const iv = uploadedBytes.subarray(0, 12)
+      const authTag = uploadedBytes.subarray(12, 28)
+      const ciphertext = uploadedBytes.subarray(28)
+      const decipher = crypto.createDecipheriv('aes-256-gcm', keyBuf, iv)
+      decipher.setAuthTag(authTag)
+      const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()])
+      expect(decrypted.toString()).toBe(TEST_CONTENT)
+    })
+  })
+
+  describe('successful x402 sell from file_path', () => {
+    it('should read file and encrypt for x402', async () => {
+      const fileContent = Buffer.from('File content for x402 sale')
+      mockReadFileSync.mockReturnValue(fileContent)
+
+      mockCallRemoteTool.mockImplementation(async (name: string, args: any) => {
+        if (name === 'fairdrop_upload_bytes') {
+          capturedUploadData = args.data_base64
+          return makeUploadResponse()
+        }
+        if (name === 'fairdrop_download_bytes') {
+          return makeDownloadResponse(capturedUploadData!)
+        }
+        throw new Error(`Unexpected tool call: ${name}`)
+      })
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ id: 'skill-002', status: 'active' }),
+      })
+
+      const result = await sellTool.execute({
+        file_path: '/tmp/test-file.tar.gz',
+        price_wei: PRICE_USDC,
+        name: 'File Skill',
+        description: 'Skill from file',
+        category: 'dataset',
+        payment_method: 'x402',
+      })
+
+      expect(result.success).toBe(true)
+      expect(result.payment_method).toBe('x402')
+      expect(mockReadFileSync).toHaveBeenCalledWith('/tmp/test-file.tar.gz')
+    })
+  })
+
+  describe('error: no content provided', () => {
+    it('should throw when neither content_base64 nor file_path is given', async () => {
+      await expect(
+        sellTool.execute({
+          price_wei: PRICE_USDC,
+          name: 'No Content',
+          description: 'Missing content',
+          category: 'other',
+          payment_method: 'x402',
+        })
+      ).rejects.toThrow('Provide content_base64 or file_path')
+    })
+  })
+
+  describe('error: empty content', () => {
+    it('should throw when file content is empty', async () => {
+      mockReadFileSync.mockReturnValue(Buffer.alloc(0))
+
+      await expect(
+        sellTool.execute({
+          file_path: '/tmp/empty-file.txt',
+          price_wei: PRICE_USDC,
+          name: 'Empty',
+          description: 'Empty content',
+          category: 'other',
+          payment_method: 'x402',
+        })
+      ).rejects.toThrow('Content is empty')
+    })
+  })
+
+  describe('error: Swarm upload fails', () => {
+    it('should throw when upload returns no reference', async () => {
+      mockCallRemoteTool.mockImplementation(async (name: string) => {
+        if (name === 'fairdrop_upload_bytes') {
+          return { reference: '' }
+        }
+        throw new Error(`Unexpected tool call: ${name}`)
+      })
+
+      await expect(
+        sellTool.execute({
+          content_base64: TEST_CONTENT_BASE64,
+          price_wei: PRICE_USDC,
+          name: 'Upload Fail',
+          description: 'Upload will fail',
+          category: 'other',
+          payment_method: 'x402',
+        })
+      ).rejects.toThrow('Swarm upload did not return a reference')
+    })
+  })
+
+  describe('error: Swarm verification fails', () => {
+    it('should throw when uploaded content cannot be verified', async () => {
+      mockCallRemoteTool.mockImplementation(async (name: string, args: any) => {
+        if (name === 'fairdrop_upload_bytes') {
+          return makeUploadResponse()
+        }
+        if (name === 'fairdrop_download_bytes') {
+          // Return empty data — verification fails
+          return { data_base64: '', size: 0 }
+        }
+        throw new Error(`Unexpected tool call: ${name}`)
+      })
+
+      await expect(
+        sellTool.execute({
+          content_base64: TEST_CONTENT_BASE64,
+          price_wei: PRICE_USDC,
+          name: 'Verify Fail',
+          description: 'Verification will fail',
+          category: 'other',
+          payment_method: 'x402',
+        })
+      ).rejects.toThrow('Swarm upload verification failed')
+    })
+  })
+
+  describe('error: marketplace publish fails', () => {
+    it('should throw when marketplace returns error', async () => {
+      mockCallRemoteTool.mockImplementation(async (name: string, args: any) => {
+        if (name === 'fairdrop_upload_bytes') {
+          capturedUploadData = args.data_base64
+          return makeUploadResponse()
+        }
+        if (name === 'fairdrop_download_bytes') {
+          return makeDownloadResponse(capturedUploadData!)
+        }
+        throw new Error(`Unexpected tool call: ${name}`)
+      })
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        text: () => Promise.resolve('Invalid content key format'),
+      })
+
+      await expect(
+        sellTool.execute({
+          content_base64: TEST_CONTENT_BASE64,
+          price_wei: PRICE_USDC,
+          name: 'Publish Fail',
+          description: 'Publish will fail',
+          category: 'other',
+          payment_method: 'x402',
+        })
+      ).rejects.toThrow('Marketplace publish failed (400): Invalid content key format')
+    })
+  })
+
+  describe('escrow flow unchanged', () => {
+    it('should not route to x402 when payment_method is not set', async () => {
+      // When payment_method is not 'x402', the escrow flow runs.
+      // The escrow flow calls createPublicClient (viem) which will fail in test
+      // because there's no real RPC. This proves we entered the escrow branch.
+      await expect(
+        sellTool.execute({
+          content_base64: TEST_CONTENT_BASE64,
+          price_wei: '1000000000000000',
+          name: 'Escrow Sell',
+          description: 'Should use escrow flow',
+          category: 'research',
+          // No payment_method — defaults to escrow
+        })
+      ).rejects.toThrow() // Will throw because escrow needs real RPC / mocked viem
+    })
+
+    it('should not route to x402 when payment_method is escrow', async () => {
+      await expect(
+        sellTool.execute({
+          content_base64: TEST_CONTENT_BASE64,
+          price_wei: '1000000000000000',
+          name: 'Escrow Sell',
+          description: 'Should use escrow flow',
+          category: 'research',
+          payment_method: 'escrow',
+        })
+      ).rejects.toThrow() // Will throw because escrow needs real RPC / mocked viem
+    })
+  })
+})

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -5,7 +5,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc"
+    "build": "tsc",
+    "test": "vitest run"
   },
   "dependencies": {
     "@fairdrop/contracts": "workspace:*",
@@ -13,6 +14,7 @@
     "ethers": "^6.13.0"
   },
   "devDependencies": {
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.0",
+    "vitest": "^4.0.18"
   }
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -9,7 +9,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@fairdrop/contracts": "workspace:*",
+    "@ade/contracts": "workspace:*",
     "@fairdrop/discovery": "workspace:*",
     "ethers": "^6.13.0"
   },

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -10,3 +10,5 @@ export type { EscrowDetails, EscrowConfig, AgentProfile, ReputationSummary, Netw
 
 export { Discovery, sanitize } from '@fairdrop/discovery';
 export type { SearchResult, SearchParams, SanitizedOffering } from '@fairdrop/discovery';
+
+export * from './x402.js';

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -5,8 +5,8 @@
  * Re-exports from contracts and discovery packages.
  */
 
-export { DataEscrow, ERC8004, ADDRESSES, TOKENS, EscrowState } from '@fairdrop/contracts';
-export type { EscrowDetails, EscrowConfig, AgentProfile, ReputationSummary, NetworkConfig } from '@fairdrop/contracts';
+export { DataEscrow, ERC8004, ADDRESSES, TOKENS, EscrowState } from '@ade/contracts';
+export type { EscrowDetails, EscrowConfig, AgentProfile, ReputationSummary, NetworkConfig } from '@ade/contracts';
 
 export { Discovery, sanitize } from '@fairdrop/discovery';
 export type { SearchResult, SearchParams, SanitizedOffering } from '@fairdrop/discovery';

--- a/packages/sdk/src/x402.ts
+++ b/packages/sdk/src/x402.ts
@@ -1,0 +1,94 @@
+import * as crypto from 'crypto'
+
+export const USDC_DECIMALS = 6
+export const ESCROW_THRESHOLD = 5_000_000n
+
+export const X402_PRICE_TIERS = [
+  { label: 'Free', amount: '0', method: 'free' as const },
+  { label: 'Micro', amount: '100000', method: 'x402' as const },
+  { label: 'Standard', amount: '500000', method: 'x402' as const },
+  { label: 'Premium', amount: '1000000', method: 'x402' as const },
+] as const
+
+export const USDC_BASE = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913'
+export const BASE_NETWORK = 'eip155:8453'
+export const BASE_SEPOLIA_NETWORK = 'eip155:84532'
+
+export function suggestPaymentMethod(priceUsdc: string): 'free' | 'x402' | 'escrow' {
+  const amount = BigInt(priceUsdc || '0')
+  if (amount === 0n) return 'free'
+  if (amount >= ESCROW_THRESHOLD) return 'escrow'
+  return 'x402'
+}
+
+export function formatUsdc(smallestUnits: string): string {
+  const n = BigInt(smallestUnits || '0')
+  const whole = n / 1_000_000n
+  const frac = n % 1_000_000n
+  if (frac === 0n) return `$${whole}.00`
+  const fracStr = frac.toString().padStart(6, '0')
+  const trimmed = fracStr.replace(/0+$/, '')
+  const display = trimmed.length < 2 ? trimmed.padEnd(2, '0') : trimmed
+  return `$${whole}.${display}`
+}
+
+export function parseUsdc(dollars: string): string {
+  const num = parseFloat(dollars)
+  if (isNaN(num) || num < 0) return '0'
+  return Math.round(num * 1_000_000).toString()
+}
+
+export function encryptContentKey(keyHex: string, masterSecretHex: string): string {
+  const master = Buffer.from(masterSecretHex, 'hex')
+  const iv = crypto.randomBytes(12)
+  const cipher = crypto.createCipheriv('aes-256-gcm', master, iv)
+  const ct = Buffer.concat([cipher.update(keyHex, 'utf8'), cipher.final()])
+  const tag = cipher.getAuthTag()
+  return Buffer.concat([iv, tag, ct]).toString('base64')
+}
+
+export function decryptContentKey(encrypted: string, masterSecretHex: string): string {
+  const master = Buffer.from(masterSecretHex, 'hex')
+  const buf = Buffer.from(encrypted, 'base64')
+  const iv = buf.subarray(0, 12)
+  const tag = buf.subarray(12, 28)
+  const ct = buf.subarray(28)
+  const decipher = crypto.createDecipheriv('aes-256-gcm', master, iv)
+  decipher.setAuthTag(tag)
+  return decipher.update(ct).toString('utf8') + decipher.final('utf8')
+}
+
+export function encryptContent(content: Buffer): { key: string; encrypted: Buffer } {
+  const key = crypto.randomBytes(32)
+  const iv = crypto.randomBytes(12)
+  const cipher = crypto.createCipheriv('aes-256-gcm', key, iv)
+  const ciphertext = Buffer.concat([cipher.update(content), cipher.final()])
+  const authTag = cipher.getAuthTag()
+  return {
+    key: key.toString('hex'),
+    encrypted: Buffer.concat([iv, authTag, ciphertext]),
+  }
+}
+
+export function decryptContent(encrypted: Buffer, keyHex: string): Buffer {
+  const key = Buffer.from(keyHex, 'hex')
+  const iv = encrypted.subarray(0, 12)
+  const authTag = encrypted.subarray(12, 28)
+  const ciphertext = encrypted.subarray(28)
+  const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv)
+  decipher.setAuthTag(authTag)
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()])
+}
+
+export function sanitizeFilename(name: string): string {
+  const cleaned = name
+    .replace(/[^a-zA-Z0-9._-]/g, '')
+    .replace(/\.{2,}/g, '.')
+    .replace(/^\.+/, '')
+    .trim()
+  return cleaned || 'download'
+}
+
+export function isValidSwarmRef(ref: string): boolean {
+  return /^[0-9a-f]{64}$/i.test(ref)
+}

--- a/packages/sdk/test/x402.test.ts
+++ b/packages/sdk/test/x402.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest'
+import {
+  suggestPaymentMethod,
+  formatUsdc,
+  parseUsdc,
+  X402_PRICE_TIERS,
+  encryptContentKey,
+  decryptContentKey,
+  encryptContent,
+  decryptContent,
+  sanitizeFilename,
+} from '../src/x402.js'
+
+describe('suggestPaymentMethod', () => {
+  it('returns free for zero', () => {
+    expect(suggestPaymentMethod('0')).toBe('free')
+    expect(suggestPaymentMethod('')).toBe('free')
+  })
+  it('returns x402 under $5', () => {
+    expect(suggestPaymentMethod('100000')).toBe('x402')
+    expect(suggestPaymentMethod('4999999')).toBe('x402')
+  })
+  it('returns escrow at $5+', () => {
+    expect(suggestPaymentMethod('5000000')).toBe('escrow')
+    expect(suggestPaymentMethod('10000000')).toBe('escrow')
+  })
+})
+
+describe('formatUsdc', () => {
+  it('formats to dollar string', () => {
+    expect(formatUsdc('500000')).toBe('$0.50')
+    expect(formatUsdc('1000000')).toBe('$1.00')
+    expect(formatUsdc('0')).toBe('$0.00')
+    expect(formatUsdc('100000')).toBe('$0.10')
+    expect(formatUsdc('1500')).toBe('$0.0015')
+    expect(formatUsdc('10000000')).toBe('$10.00')
+  })
+})
+
+describe('parseUsdc', () => {
+  it('converts dollars to smallest units', () => {
+    expect(parseUsdc('0.50')).toBe('500000')
+    expect(parseUsdc('1')).toBe('1000000')
+    expect(parseUsdc('5')).toBe('5000000')
+  })
+  it('returns 0 for invalid input', () => {
+    expect(parseUsdc('abc')).toBe('0')
+    expect(parseUsdc('-1')).toBe('0')
+  })
+})
+
+describe('X402_PRICE_TIERS', () => {
+  it('has 4 tiers', () => {
+    expect(X402_PRICE_TIERS).toHaveLength(4)
+    expect(X402_PRICE_TIERS[0].label).toBe('Free')
+    expect(X402_PRICE_TIERS[3].label).toBe('Premium')
+  })
+})
+
+describe('content key encryption', () => {
+  const masterSecret = 'a'.repeat(64)
+
+  it('round-trips key encryption', () => {
+    const originalKey = 'b'.repeat(64)
+    const encrypted = encryptContentKey(originalKey, masterSecret)
+    expect(encrypted).not.toBe(originalKey)
+    const decrypted = decryptContentKey(encrypted, masterSecret)
+    expect(decrypted).toBe(originalKey)
+  })
+
+  it('produces different ciphertext each time (random IV)', () => {
+    const key = 'c'.repeat(64)
+    const e1 = encryptContentKey(key, masterSecret)
+    const e2 = encryptContentKey(key, masterSecret)
+    expect(e1).not.toBe(e2)
+  })
+})
+
+describe('content encryption', () => {
+  it('round-trips content', () => {
+    const original = Buffer.from('hello world test content')
+    const { key, encrypted } = encryptContent(original)
+    expect(key).toHaveLength(64)
+    expect(encrypted.length).toBeGreaterThan(original.length)
+    const decrypted = decryptContent(encrypted, key)
+    expect(decrypted.toString()).toBe(original.toString())
+  })
+})
+
+describe('sanitizeFilename', () => {
+  it('strips path traversal', () => {
+    expect(sanitizeFilename('../../etc/passwd')).toBe('etcpasswd')
+  })
+  it('strips non-whitelisted characters', () => {
+    expect(sanitizeFilename('file"name;bad\n.tar.gz')).toBe('filenamebad.tar.gz')
+  })
+  it('preserves normal filenames', () => {
+    expect(sanitizeFilename('my-pack-v1.tar.gz')).toBe('my-pack-v1.tar.gz')
+  })
+  it('falls back to download for empty', () => {
+    expect(sanitizeFilename('')).toBe('download')
+    expect(sanitizeFilename('...')).toBe('download')
+  })
+  it('strips leading dots (no hidden files)', () => {
+    expect(sanitizeFilename('.hidden')).toBe('hidden')
+    expect(sanitizeFilename('..config')).toBe('config')
+  })
+})

--- a/packages/sdk/vitest.config.ts
+++ b/packages/sdk/vitest.config.ts
@@ -1,0 +1,2 @@
+import { defineConfig } from 'vitest/config'
+export default defineConfig({ test: { globals: true } })

--- a/packages/skill/package.json
+++ b/packages/skill/package.json
@@ -8,7 +8,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@fairdrop/contracts": "workspace:*",
+    "@ade/contracts": "workspace:*",
     "@fairdrop/discovery": "workspace:*",
     "ethers": "^6.13.0"
   },

--- a/packages/skill/src/skill.ts
+++ b/packages/skill/src/skill.ts
@@ -17,7 +17,7 @@
 
 import { webcrypto as crypto } from 'crypto';
 import { ethers, JsonRpcProvider } from 'ethers';
-import { DataEscrow, ERC8004, ADDRESSES, EscrowState } from '@fairdrop/contracts';
+import { DataEscrow, ERC8004, ADDRESSES, EscrowState } from '@ade/contracts';
 import { Discovery, type SearchResult, type SanitizedOffering } from '@fairdrop/discovery';
 import { Wallet } from './wallet.js';
 import { Stamps, type StampInfo } from './stamps.js';


### PR DESCRIPTION
## Summary

- Add x402 payment handler to agents-api with facilitator-based settlement
- Add x402 buy/sell tools to MCP server
- Add PaymentProxy Solidity contract with Foundry tests
- Add SDK helpers for pricing, USDC formatting, content encryption

## Key changes

### agents-api
- `x402-download.ts` — x402 paywall handler with re-download support
- Network-configurable via `X402_NETWORK` env var (Base mainnet default, Sepolia supported)
- `x402_payments` DB table for payment records
- `engram-pack` product type registration

### MCP
- `df_sell` enhanced with `--payment x402` flow
- `df_buy_x402` tool for EIP-3009 authorized purchases
- Local key backup for x402 listings

### Contracts
- `PaymentProxy.sol` — USDC forwarding with fee collection, relayer ACL
- 11 Foundry tests covering all paths

## Test plan

- [x] agents-api: 56 tests pass (including 9 x402-specific)
- [x] MCP: 108 tests pass (including buy-x402 detection, sell-x402)
- [ ] E2E on Base Sepolia (post-merge)
- [ ] Production smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code)